### PR TITLE
Add address normalization automation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           pip install -r requirements-dev.txt
-      - name: Populate .env file
-        run: |
-          echo "${{ secrets.BAM_ENV_FILE_CONTENTS }}" > ./.env
       - name: Run core tests
         run: |
           pip install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           pip install -r requirements-dev.txt
+      - name: Populate .env file
+        run: |
+          echo "${{ secrets.BAM_ENV_FILE_CONTENTS }}" > ./.env
       - name: Run core tests
         run: |
           pip install .

--- a/app/bam_app/main.py
+++ b/app/bam_app/main.py
@@ -27,10 +27,10 @@ def clean_record(
     apikey: str,
     phone: str = None,
     email: str = None,
+    dns_check: bool = False,
     address: str = None,
     city_state: str = "",
     zip_code: str = "",
-    dns_check: bool = False,
 ):
     """
     :param phone_number: The phone number to validate

--- a/app/bam_app/main.py
+++ b/app/bam_app/main.py
@@ -5,6 +5,7 @@ from fastapi.security import OAuth2PasswordBearer
 
 from bam_core.utils.phone import format_phone_number
 from bam_core.utils.email import format_email
+from bam_core.utils.geo import format_address
 
 
 app = FastAPI()
@@ -26,8 +27,10 @@ def clean_record(
     apikey: str,
     phone: str = None,
     email: str = None,
-    dns_check: bool = False,
     address: str = None,
+    city_state: str = "",
+    zip_code: str = "",
+    dns_check: bool = False,
 ):
     """
     :param phone_number: The phone number to validate
@@ -60,8 +63,10 @@ def clean_record(
 
     # validate mailing address
     if address:
-        # TOOO: add address cleaning
-        pass
+        address_response = format_address(
+            address=address, city_state=city_state, zipcode=zip_code
+        )
+        response.update(address_response)
     return response
 
 

--- a/core/bam_core/constants.py
+++ b/core/bam_core/constants.py
@@ -586,5 +586,5 @@ VIEWS: list[View] = (
 # Geolocation constants
 
 # location of mayday used to help lookup addresses
-MAYDAY_LOCATION = {'lat': 40.7041015, 'lng': -73.9163523}
-MAYDAY_RADIUS = 16093.44 # 10 miles in meters
+MAYDAY_LOCATION = {"lat": 40.7041015, "lng": -73.9163523}
+MAYDAY_RADIUS = 16093.44  # 10 miles in meters

--- a/core/bam_core/constants.py
+++ b/core/bam_core/constants.py
@@ -587,4 +587,4 @@ VIEWS: list[View] = (
 
 # location of mayday used to help lookup addresses
 MAYDAY_LOCATION = {'lat': 40.7041015, 'lng': -73.9163523}
-MAYDAY_RADIUS = 8046.72 # 5 miles in meters
+MAYDAY_RADIUS = 16093.44 # 10 miles in meters

--- a/core/bam_core/constants.py
+++ b/core/bam_core/constants.py
@@ -581,3 +581,10 @@ VIEWS: list[View] = (
 #         timeout_flag_value="Groceries Request Timeout",
 #     )
 # ]
+
+
+# Geolocation constants
+
+# location of mayday used to help lookup addresses
+MAYDAY_LOCATION = {'lat': 40.7041015, 'lng': -73.9163523}
+MAYDAY_RADIUS = 8046.72 # 5 miles in meters

--- a/core/bam_core/functions/base.py
+++ b/core/bam_core/functions/base.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 from bam_core.lib.airtable import Airtable
 from bam_core.lib.mailjet import Mailjet
 from bam_core.lib.s3 import S3
+from bam_core.lib.google import GoogleMaps
+from bam_core.lib.nyc_planning_labs import NycPlanningLabs
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +20,8 @@ class Function(object):
     mailjet = Mailjet()
     airtable = Airtable()
     s3 = S3()
+    gmaps = GoogleMaps()
+    nycpl = NycPlanningLabs()
 
     def __init__(self, parser: Optional[ArgumentParser] = None):
         self.parser = parser or ArgumentParser(

--- a/core/bam_core/lib/airtable.py
+++ b/core/bam_core/lib/airtable.py
@@ -9,8 +9,6 @@ from bam_core import settings
 from bam_core.utils.etc import to_list
 from bam_core.constants import (
     AIRTABLE_DATETIME_FORMAT,
-    EG_REQUESTS_FIELD,
-    EG_STATUS_FIELD,
     PHONE_FIELD,
     ASSISTANCE_REQUESTS_TABLE_NAME,
     ESSENTIAL_GOODS_TABLE_NAME,

--- a/core/bam_core/lib/airtable.py
+++ b/core/bam_core/lib/airtable.py
@@ -63,7 +63,9 @@ class Airtable(object):
         :param table_name: The name of the table to get
         :return Table
         """
-        records = self.get_view(table_name=table, view_name=view, fields=fields)
+        records = self.get_view(
+            table_name=table, view_name=view, fields=fields
+        )
         if unique and len(fields) and len(records):
             uniques = set()
             for r in records:
@@ -243,7 +245,9 @@ class Airtable(object):
                     )
                     continue
 
-                delivered_tags = to_list(request_tag_schema.get("delivered", []))
+                delivered_tags = to_list(
+                    request_tag_schema.get("delivered", [])
+                )
                 timeout_tags = to_list(request_tag_schema.get("timeout", []))
                 invalid_tags = to_list(request_tag_schema.get("invalid", []))
                 missed_tag = request_tag_schema.get("missed", None)
@@ -291,9 +295,13 @@ class Airtable(object):
                         sub_invalid_tags = to_list(
                             sub_request_tag_schema.get("invalid", [])
                         )
-                        sub_missed_tag = sub_request_tag_schema.get("missed", None)
+                        sub_missed_tag = sub_request_tag_schema.get(
+                            "missed", None
+                        )
 
-                        sub_sub_item_schema = sub_request_tag_schema.get("items", None)
+                        sub_sub_item_schema = sub_request_tag_schema.get(
+                            "items", None
+                        )
 
                         if not sub_sub_item_schema:
                             analysis = cls._perform_request_analysis(
@@ -313,15 +321,25 @@ class Airtable(object):
                             #########################
 
                             # handle doubly nested requests
-                            sub_sub_request_field = sub_sub_item_schema["request_field"]
-                            sub_sub_status_field = sub_sub_item_schema["status_field"]
-                            sub_sub_request_tags = record.get(sub_sub_request_field, [])
-                            sub_sub_status_tags = record.get(sub_sub_status_field, [])
+                            sub_sub_request_field = sub_sub_item_schema[
+                                "request_field"
+                            ]
+                            sub_sub_status_field = sub_sub_item_schema[
+                                "status_field"
+                            ]
+                            sub_sub_request_tags = record.get(
+                                sub_sub_request_field, []
+                            )
+                            sub_sub_status_tags = record.get(
+                                sub_sub_status_field, []
+                            )
 
                             for sub_sub_request_tag in sub_sub_request_tags:
-                                sub_sub_request_tag_schema = sub_sub_item_schema[
-                                    "items"
-                                ].get(sub_sub_request_tag, None)
+                                sub_sub_request_tag_schema = (
+                                    sub_sub_item_schema["items"].get(
+                                        sub_sub_request_tag, None
+                                    )
+                                )
                                 if not sub_sub_request_tag_schema:
                                     log.warning(
                                         f"Unknown request tag '{sub_sub_request_tag}' for field '{sub_sub_request_field}'"
@@ -329,16 +347,24 @@ class Airtable(object):
                                     continue
 
                                 sub_sub_delivered_tags = to_list(
-                                    sub_sub_request_tag_schema.get("delivered", [])
+                                    sub_sub_request_tag_schema.get(
+                                        "delivered", []
+                                    )
                                 )
                                 sub_sub_timeout_tags = to_list(
-                                    sub_sub_request_tag_schema.get("timeout", [])
+                                    sub_sub_request_tag_schema.get(
+                                        "timeout", []
+                                    )
                                 )
                                 sub_sub_invalid_tags = to_list(
-                                    sub_sub_request_tag_schema.get("invalid", [])
+                                    sub_sub_request_tag_schema.get(
+                                        "invalid", []
+                                    )
                                 )
-                                sub_sub_missed_tag = sub_sub_request_tag_schema.get(
-                                    "missed", None
+                                sub_sub_missed_tag = (
+                                    sub_sub_request_tag_schema.get(
+                                        "missed", None
+                                    )
                                 )
 
                                 analysis = cls._perform_request_analysis(
@@ -347,7 +373,8 @@ class Airtable(object):
                                     sub_sub_request_tag,
                                     sub_sub_status_tags,
                                     # respect delivered tags from one level up (only relevant for Beds)
-                                    sub_delivered_tags + sub_sub_delivered_tags,
+                                    sub_delivered_tags
+                                    + sub_sub_delivered_tags,
                                     sub_sub_timeout_tags
                                     + sub_timeout_tags
                                     + timeout_tags,

--- a/core/bam_core/lib/google.py
+++ b/core/bam_core/lib/google.py
@@ -1,0 +1,46 @@
+import googlemaps
+
+from bam_core.settings import GOOGLE_MAPS_API_KEY
+from bam_core.constants import MAYDAY_LOCATION, MAYDAY_RADIUS
+
+
+class GoogleMaps(object):
+    def __init__(self, api_key=GOOGLE_MAPS_API_KEY):
+        self.api_key = api_key
+        self.client = googlemaps.Client(key=api_key)
+
+    def get_place(
+        self,
+        address,
+        location=MAYDAY_LOCATION,
+        radius=MAYDAY_RADIUS,
+        types=["premise", "subpremise", "geocode"],
+        language="en-US",
+        strict_bounds=True,
+    ):
+        """
+        Get a place from the Google Maps API
+        Args:
+            address (str): The address to search for
+            location (tuple): The location to search around
+            radius (int): The radius to search within
+            types (list): The types of places to search for
+            language (str): The language to search in
+            strict_bounds (bool): Whether to use strict bounds
+        """
+        return self.client.places_autocomplete(
+            address,
+            location=location,
+            radius=radius,
+            types=types,
+            language=language,
+            strict_bounds=strict_bounds,
+        )
+
+    def get_normalized_address(self, address):
+        """
+        Normalize an address using the Google Maps API
+        Args:
+            address (str): The address to normalize
+        """
+        return self.client.addressvalidation(address)

--- a/core/bam_core/lib/google.py
+++ b/core/bam_core/lib/google.py
@@ -6,7 +6,11 @@ from bam_core.constants import MAYDAY_LOCATION, MAYDAY_RADIUS
 
 class GoogleMaps(object):
     def __init__(self, api_key=GOOGLE_MAPS_API_KEY):
-        self.client = googlemaps.Client(key=api_key)
+        self.api_key = api_key
+
+    @property
+    def client(self):
+        return googlemaps.Client(key=self.api_key)
 
     def get_place(
         self,

--- a/core/bam_core/lib/google.py
+++ b/core/bam_core/lib/google.py
@@ -6,7 +6,6 @@ from bam_core.constants import MAYDAY_LOCATION, MAYDAY_RADIUS
 
 class GoogleMaps(object):
     def __init__(self, api_key=GOOGLE_MAPS_API_KEY):
-        self.api_key = api_key
         self.client = googlemaps.Client(key=api_key)
 
     def get_place(

--- a/core/bam_core/lib/nyc_planning_labs.py
+++ b/core/bam_core/lib/nyc_planning_labs.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict
+import requests
+
+
+class NycPlanningLabs(object):
+    base_url = "https://geosearch.planninglabs.nyc/v2"
+
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update(
+            {"Content-Type": "application/json", "Accept": "application/json"}
+        )
+
+    def search(self, text: str, size: int = 1) -> Dict[str, Any]:
+        """
+        Search for a location in NYC using the geosearch API
+        Args:
+            text (str): The text to search for
+            size (int): The number of results to return
+        Returns:
+            Dict[str, Any]: The response from the geosearch API
+        """
+        url = f"{self.base_url}/search"
+        params = {"text": text, "size": size}
+        response = self.session.get(url, params=params)
+        response.raise_for_status
+        return response.json()

--- a/core/bam_core/settings.py
+++ b/core/bam_core/settings.py
@@ -13,6 +13,9 @@ AIRTABLE_BASE_ID = os.getenv("BAM_AIRTABLE_BASE_ID", None)
 MAILJET_API_KEY = os.getenv("BAM_MAILJET_API_KEY", None)
 MAILJET_API_SECRET = os.getenv("BAM_MAILJET_API_SECRET", None)
 
+# google settings
+GOOGLE_MAPS_API_KEY = os.getenv("BAM_GOOGLE_MAPS_API_KEY", None)
+
 # s3 settings
 DO_TOKEN = os.getenv("BAM_DO_TOKEN", None)
 S3_BASE_URL = os.getenv(

--- a/core/bam_core/utils/email.py
+++ b/core/bam_core/utils/email.py
@@ -220,4 +220,3 @@ def format_email(email: str, dns_check: bool = False) -> Dict[str, str]:
         return {"email": email_info.normalized, "error": ""}
     except EmailNotValidError as e:
         return {"email": email, "error": str(e)}
-    

--- a/core/bam_core/utils/geo.py
+++ b/core/bam_core/utils/geo.py
@@ -31,7 +31,7 @@ def format_address(
     # connect to APIs
     gmaps = GoogleMaps()
     nycpl = NycPlanningLabs()
-    
+
     response = {
         "cleaned_address": "",
         "bin": "",

--- a/core/bam_core/utils/geo.py
+++ b/core/bam_core/utils/geo.py
@@ -1,0 +1,96 @@
+from typing import Dict, Optional
+from bam_core.lib.google import GoogleMaps
+from bam_core.lib.nyc_planning_labs import NycPlanningLabs
+
+gmaps = GoogleMaps()
+nycpl = NycPlanningLabs()
+
+COMMON_ZIPCODE_MISTAKES = {
+    "112007": "11207",
+}
+
+
+def _fix_zip_code(zip_code: Optional[str]) -> str:
+    """
+    Attempt to fix common mistakes in zipcodes
+    """
+    return COMMON_ZIPCODE_MISTAKES.get(zip_code, zip_code)
+
+
+def format_address(
+    address: Optional[str] = None,
+    city_state: Optional[str] = "",
+    zipcode: Optional[str] = "",
+) -> Dict[str, str]:
+    """
+    Format an address using the Google Maps API and the NYC Planning Labs API
+    Args:
+        address (str): The address to format
+        city_state (str): The city and state to use if the address is missing
+        zipcode (str): The zipcode to use if the address is missing
+    Returns:
+        Dict[str, str]: The formatted address, bin, and accuracy
+    """
+    response = {
+        "cleaned_address": "",
+        "bin": "",
+        "cleaned_address_accuracy": "No result",
+    }
+    # don't do anything for missing addresses
+    if not address or not address.strip():
+        return response
+
+    # format address for query
+    address_query = f"{address.strip()} {city_state.strip() or 'New York'} {_fix_zip_code(zipcode.strip())}".strip().upper()
+
+    # lookup address using Google Maps Places API
+    place_response = gmaps.get_place(address_query)
+    if not len(place_response):
+        return response
+
+    place_address = place_response[0]["description"]
+    if "subpremise" in place_response[0]["types"]:
+        response["cleaned_address_accuracy"] = "Apartment"
+    elif "premise" in place_response[0]["types"]:
+        response["cleaned_address_accuracy"] = "Building"
+    else:
+        # ignore geocode results if not at the level of a building or apartment
+        return response
+
+    # lookup the cleaned address using the google maps address validation api
+    norm_address_result = gmaps.get_normalized_address(place_address)
+
+    norm_address = norm_address_result.get("result", {})
+    ## TODO: Figure out if we should report granularity from here or places API
+    # granularity = norm_address.get("verdict", {}).get("validationGranularity", "")
+    # if granularity == "SUB_PREMISE":
+    #     response["cleaned_address_accuracy"] = "Apartment"
+    # elif granularity == "PREMISE":
+    #     response["cleaned_address_accuracy"] = "Building"
+
+    usps_data = norm_address.get("uspsData", {}).get("standardizedAddress", {})
+    cleaned_address = (
+        usps_data.get("firstAddressLine", "")
+        + " "
+        + usps_data.get("cityStateZipAddressLine", "")
+    ).strip()
+    if not cleaned_address:
+        # if no USPS data, use the formatted address
+        cleaned_address = (
+            norm_address.get("address", {}).get("formattedAddress", "").upper()
+        )
+        # if no formatted address, use the place address
+        if not cleaned_address:
+            cleaned_address = place_address.upper()
+    response["cleaned_address"] = cleaned_address
+
+    # lookup the bin using the nyc planning labs api
+    nycpl_response = nycpl.search(cleaned_address)
+    response["bin"] = (
+        nycpl_response.get("features", [{}])[0]
+        .get("properties", {})
+        .get("addendum", {})
+        .get("pad", {})
+        .get("bin", "")
+    )
+    return response

--- a/core/bam_core/utils/geo.py
+++ b/core/bam_core/utils/geo.py
@@ -2,9 +2,6 @@ from typing import Dict, Optional
 from bam_core.lib.google import GoogleMaps
 from bam_core.lib.nyc_planning_labs import NycPlanningLabs
 
-gmaps = GoogleMaps()
-nycpl = NycPlanningLabs()
-
 COMMON_ZIPCODE_MISTAKES = {
     "112007": "11207",
 }
@@ -31,6 +28,10 @@ def format_address(
     Returns:
         Dict[str, str]: The formatted address, bin, and accuracy
     """
+    # connect to APIs
+    gmaps = GoogleMaps()
+    nycpl = NycPlanningLabs()
+    
     response = {
         "cleaned_address": "",
         "bin": "",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "email-validator==2.0.0.post2",
     "charset-normalizer==3.2.0",
     "pytz==2023.3.post1",
+    "googlemaps==4.10.0",
 ]
 
 [build-system]

--- a/core/tests/lib/test_airtable_analyze_requests.py
+++ b/core/tests/lib/test_airtable_analyze_requests.py
@@ -21,7 +21,10 @@ def test_analyze_requests_simple():
                 "Alimentos / Groceries / 杂货",
                 "Comida caliente / Hot meals / 热食",
             ],
-            FOOD_STATUS_FIELD: ["Groceries Delivered", "Hot Food Request Timeout"],
+            FOOD_STATUS_FIELD: [
+                "Groceries Delivered",
+                "Hot Food Request Timeout",
+            ],
             EG_REQUESTS_FIELD: [
                 "Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴产品",
                 "Productos Femenino - Toallitas / Feminine Products - Pads / 卫生巾",
@@ -55,8 +58,12 @@ def test_analyze_requests_simple():
     assert analysis[FOOD_REQUESTS_FIELD]["timeout"] == [
         "Comida caliente / Hot meals / 热食"
     ]
-    assert analysis[EG_REQUESTS_FIELD]["open"] == ["Pañales / Baby Diapers / 婴儿纸尿裤"]
-    assert analysis[FOOD_REQUESTS_FIELD]["delivered"] == ["Alimentos / Groceries / 杂货"]
+    assert analysis[EG_REQUESTS_FIELD]["open"] == [
+        "Pañales / Baby Diapers / 婴儿纸尿裤"
+    ]
+    assert analysis[FOOD_REQUESTS_FIELD]["delivered"] == [
+        "Alimentos / Groceries / 杂货"
+    ]
     assert analysis[SOCIAL_SERVICES_REQUESTS_FIELD]["timeout"] == [
         "Asistencia asegurando vivienda/ Securing housing / 住房援助"
     ]
@@ -89,12 +96,16 @@ def test_analyze_requests_missed_appt():
         "Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴产品",
         "Productos Femenino - Toallitas / Feminine Products - Pads / 卫生巾",
     ]
-    assert analysis[FOOD_REQUESTS_FIELD]["missed"] == ["Alimentos / Groceries / 杂货"]
+    assert analysis[FOOD_REQUESTS_FIELD]["missed"] == [
+        "Alimentos / Groceries / 杂货"
+    ]
     assert analysis[EG_REQUESTS_FIELD]["open"] == [
         "Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴产品",
         "Productos Femenino - Toallitas / Feminine Products - Pads / 卫生巾",
     ]
-    assert analysis[FOOD_REQUESTS_FIELD]["open"] == ["Alimentos / Groceries / 杂货"]
+    assert analysis[FOOD_REQUESTS_FIELD]["open"] == [
+        "Alimentos / Groceries / 杂货"
+    ]
 
 
 def test_analyze_requests_no_status():
@@ -114,7 +125,9 @@ def test_analyze_requests_no_status():
         "Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴产品",
         "Productos Femenino - Toallitas / Feminine Products - Pads / 卫生巾",
     ]
-    assert analysis[FOOD_REQUESTS_FIELD]["open"] == ["Alimentos / Groceries / 杂货"]
+    assert analysis[FOOD_REQUESTS_FIELD]["open"] == [
+        "Alimentos / Groceries / 杂货"
+    ]
 
 
 def test_analyze_requests_one_level_of_nesting():
@@ -147,7 +160,9 @@ def test_analyze_requests_one_level_of_nesting():
     assert analysis[FURNITURE_REQUESTS_FIELD]["delivered"] == [
         "Cajonera / Clothes Dresser / 衣服梳妆台"
     ]
-    assert analysis[KITCHEN_REQUESTS_FIELD]["timeout"] == ["Platos / Plates / 板块"]
+    assert analysis[KITCHEN_REQUESTS_FIELD]["timeout"] == [
+        "Platos / Plates / 板块"
+    ]
     assert analysis[KITCHEN_REQUESTS_FIELD]["delivered"] == [
         "Ollas y Sartenes / Pots & Pans / 锅碗瓢盆"
     ]
@@ -162,7 +177,9 @@ def test_analyze_requests_two_levels_of_nesting_specific_delivered_tag():
             FURNITURE_REQUESTS_FIELD: [
                 "Cama / Bed / 床",
             ],
-            BED_REQUESTS_FIELD: ["Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"],
+            BED_REQUESTS_FIELD: [
+                "Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"
+            ],
             EG_STATUS_FIELD: ["Queen Bed Set Delivered"],
         }
     }
@@ -181,7 +198,9 @@ def test_analyze_requests_two_levels_of_nesting_parent_delivered_tag():
             FURNITURE_REQUESTS_FIELD: [
                 "Cama / Bed / 床",
             ],
-            BED_REQUESTS_FIELD: ["Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"],
+            BED_REQUESTS_FIELD: [
+                "Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"
+            ],
             EG_STATUS_FIELD: ["Mattress Delivered"],
         }
     }
@@ -200,7 +219,9 @@ def test_analyze_requests_two_levels_of_nesting_specific_timeout_tag():
             FURNITURE_REQUESTS_FIELD: [
                 "Cama / Bed / 床",
             ],
-            BED_REQUESTS_FIELD: ["Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"],
+            BED_REQUESTS_FIELD: [
+                "Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"
+            ],
             EG_STATUS_FIELD: ["Queen Bed Set Timeout"],
         }
     }
@@ -218,7 +239,9 @@ def test_analyze_requests_two_levels_of_nesting_parent_timeout_tag():
         FURNITURE_REQUESTS_FIELD: [
             "Cama / Bed / 床",
         ],
-        BED_REQUESTS_FIELD: ["Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"],
+        BED_REQUESTS_FIELD: [
+            "Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"
+        ],
         EG_STATUS_FIELD: ["Mattress Timeout"],
     }
     analysis = Airtable.analyze_requests(record)
@@ -236,7 +259,9 @@ def test_analyze_requests_two_levels_of_nesting_grandparent_timeout_tag():
             FURNITURE_REQUESTS_FIELD: [
                 "Cama / Bed / 床",
             ],
-            BED_REQUESTS_FIELD: ["Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"],
+            BED_REQUESTS_FIELD: [
+                "Cama tamaño Queen / Queen Mattress + Frame / 全床垫+框架"
+            ],
             EG_STATUS_FIELD: ["Furniture Timeout"],
         }
     }

--- a/core/tests/test_email.py
+++ b/core/tests/test_email.py
@@ -221,6 +221,7 @@ def test_dot_instead_of_at_symbol():
     result = format_email(email)
     assert result["email"] == "another.person@gmail.com"
 
+
 def test_dot_col():
     email = "test@gmail.col"
     result = format_email(email)

--- a/core/tests/test_etc.py
+++ b/core/tests/test_etc.py
@@ -1,5 +1,6 @@
 from bam_core.utils.etc import to_list
 
+
 def test_to_list():
     assert [1] == to_list(1)
     assert [1] == to_list([1])


### PR DESCRIPTION
This adds address normalization via Google Maps + NYC Planning Labs. It adds this functionality to our `/clean-records` API so that every new address request is automatically formatted according to USPS standards and, when available, includes NYC's Building Identification Number. 