### PR TITLE
Function for analyzing request snapshots

### DIFF
--- a/core/bam_core/constants.py
+++ b/core/bam_core/constants.py
@@ -7,6 +7,7 @@ AIRTABLE_DATETIME_FORMAT = r"%Y-%m-%dT%H:%M:%S.%fZ"
 ASSISTANCE_REQUESTS_TABLE_NAME = "Assistance Requests: Main"
 VOLUNTEERS_TABLE_NAME = "Volunteers: Main"
 ESSENTIAL_GOODS_TABLE_NAME = "Essential Good Donations: Main"
+FULFILLED_REQUESTS_TABLE_NAME = "Fulfilled Requests: Main"
 
 # Airtable field name for phone numbers
 PHONE_FIELD = "Phone Number"

--- a/core/bam_core/functions/analyze_fulfilled_requests.py
+++ b/core/bam_core/functions/analyze_fulfilled_requests.py
@@ -49,7 +49,9 @@ class AnalyzeFulfilledRequests(Function):
             if contents:
                 file_records = json_to_obj(contents)
                 for record in file_records:
-                    record[SNAPSHOT_DATE_FIELD] = snapshot_date.date().isoformat()
+                    record[
+                        SNAPSHOT_DATE_FIELD
+                    ] = snapshot_date.date().isoformat()
                     grouped_records[record["id"]].append(record)
         return grouped_records
 
@@ -66,7 +68,9 @@ class AnalyzeFulfilledRequests(Function):
                 continue
             last_statuses = {}
             # iterate through snapshots for this record id
-            for record in sorted(group_records, key=lambda r: r[SNAPSHOT_DATE_FIELD]):
+            for record in sorted(
+                group_records, key=lambda r: r[SNAPSHOT_DATE_FIELD]
+            ):
                 these_statuses = Airtable.analyze_requests(record)
                 # iterate through tag types
                 for tag_type, these_tag_statuses in these_statuses.items():
@@ -84,7 +88,9 @@ class AnalyzeFulfilledRequests(Function):
                                         "Assistance Request": [request_id],
                                         "Type": tag_type,
                                         "Delivered Item": item,
-                                        "Date Delivered": record[SNAPSHOT_DATE_FIELD],
+                                        "Date Delivered": record[
+                                            SNAPSHOT_DATE_FIELD
+                                        ],
                                         "Unique ID": f"{request_id}-{tag_type}-{item}",
                                     }
                                 }

--- a/core/bam_core/functions/analyze_fulfilled_requests.py
+++ b/core/bam_core/functions/analyze_fulfilled_requests.py
@@ -10,7 +10,7 @@ from bam_core.lib.airtable import Airtable
 log = logging.getLogger(__name__)
 
 SNAPSHOT_DATE_FORMAT = r"%Y-%m-%d-%H-%M-%S"
-SNAPSHOT_FIELD = "Snapshot Date"
+SNAPSHOT_DATE_FIELD = "Snapshot Date"
 
 
 class AnalyzeFulfilledRequests(Function):
@@ -49,7 +49,7 @@ class AnalyzeFulfilledRequests(Function):
             if contents:
                 file_records = json_to_obj(contents)
                 for record in file_records:
-                    record[SNAPSHOT_FIELD] = snapshot_date.date().isoformat()
+                    record[SNAPSHOT_DATE_FIELD] = snapshot_date.date().isoformat()
                     grouped_records[record["id"]].append(record)
         return grouped_records
 
@@ -66,7 +66,7 @@ class AnalyzeFulfilledRequests(Function):
                 continue
             last_statuses = {}
             # iterate through snapshots for this record id
-            for record in sorted(group_records, key=lambda r: r[SNAPSHOT_FIELD]):
+            for record in sorted(group_records, key=lambda r: r[SNAPSHOT_DATE_FIELD]):
                 these_statuses = Airtable.analyze_requests(record)
                 # iterate through tag types
                 for tag_type, these_tag_statuses in these_statuses.items():
@@ -80,11 +80,11 @@ class AnalyzeFulfilledRequests(Function):
                             fulfilled_requests.append(
                                 {
                                     "fields": {
-                                        "Date / Delivered Item": f"{record['Snapshot Date']}: {item}",
+                                        "Date / Delivered Item": f"{record[SNAPSHOT_DATE_FIELD]}: {item}",
                                         "Assistance Request": [request_id],
                                         "Type": tag_type,
                                         "Delivered Item": item,
-                                        "Date Delivered": record["Snapshot Date"],
+                                        "Date Delivered": record[SNAPSHOT_DATE_FIELD],
                                         "Unique ID": f"{request_id}-{tag_type}-{item}",
                                     }
                                 }

--- a/core/bam_core/functions/analyze_request_snapshots.py
+++ b/core/bam_core/functions/analyze_request_snapshots.py
@@ -66,7 +66,9 @@ class AnalyzeRequestSnapshots(Function):
                 continue
             last_statuses = {}
             # iterate through snapshots for this record id
-            for record in sorted(group_records, key=lambda r: r[SNAPSHOT_FIELD]):
+            for record in sorted(
+                group_records, key=lambda r: r[SNAPSHOT_FIELD]
+            ):
                 these_statuses = Airtable.analyze_requests(record)
                 # iterate through tag types
                 for tag_type, these_tag_statuses in these_statuses.items():
@@ -83,7 +85,6 @@ class AnalyzeRequestSnapshots(Function):
                                     "type": tag_type,
                                     "item": item,
                                     "snapshot_date": record["Snapshot Date"],
-                                    "last_modified": record["Last Modified"],
                                 }
                             )
                 last_statuses = these_statuses
@@ -97,10 +98,8 @@ class AnalyzeRequestSnapshots(Function):
         grouped_records = self.get_grouped_records()
         delivered_items = self.analyze_grouped_records(grouped_records)
         log.info(f"Found {len(delivered_items)} delivered items")
-        print(delivered_items[-1])
         return delivered_items
 
 
 if __name__ == "__main__":
     AnalyzeRequestSnapshots().cli()
-

--- a/core/bam_core/functions/analyze_request_snapshots.py
+++ b/core/bam_core/functions/analyze_request_snapshots.py
@@ -1,0 +1,106 @@
+from datetime import datetime
+import logging
+from collections import defaultdict
+from typing import Any, Dict, List
+
+from .base import Function
+from bam_core.utils.serde import json_to_obj
+from bam_core.lib.airtable import Airtable
+
+log = logging.getLogger(__name__)
+
+SNAPSHOT_DATE_FORMAT = r"%Y-%m-%d-%H-%M-%S"
+SNAPSHOT_FIELD = "Snapshot Date"
+
+
+class AnalyzeRequestSnapshots(Function):
+    def add_options(self):
+        self.parser.add_argument(
+            "-d",
+            dest="DRY_RUN",
+            help="If true, data will not be written back to Airtable.",
+            action="store_true",
+            default=False,
+        )
+
+    def get_snapshot_date(self, filepath):
+        """
+        Get snapshot date from filepath
+        """
+        return datetime.strptime(
+            filepath.split("/assistance-requests-main-")[-1].split(".")[0],
+            SNAPSHOT_DATE_FORMAT,
+        )
+
+    def get_grouped_records(self):
+        """
+        Get records from Digital Ocean Space
+        """
+        grouped_records = defaultdict(list)
+        log.info("Fetching snapshots from Digital Ocean Space...")
+        for filepath in self.s3.list_keys(
+            "airtable-snapshots/assistance-requests-main/"
+        ):
+            if not filepath.endswith(".json"):
+                continue
+            log.debug(f"Fetching records from {filepath}")
+            snapshot_date = self.get_snapshot_date(filepath)
+            contents = self.s3.get_contents(filepath).decode("utf-8")
+            if contents:
+                file_records = json_to_obj(contents)
+                for record in file_records:
+                    record[SNAPSHOT_FIELD] = snapshot_date.date().isoformat()
+                    grouped_records[record["id"]].append(record)
+        return grouped_records
+
+    def analyze_grouped_records(
+        self, grouped_records: Dict[str, List[Dict[str, Any]]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Analyze grouped records and return a list of delivered items
+        """
+        delivered_items = []
+        # iterate through list of snapshots for each record id
+        for request_id, group_records in grouped_records.items():
+            if len(group_records) < 2:
+                continue
+            last_statuses = {}
+            # iterate through snapshots for this record id
+            for record in sorted(group_records, key=lambda r: r[SNAPSHOT_FIELD]):
+                these_statuses = Airtable.analyze_requests(record)
+                # iterate through tag types
+                for tag_type, these_tag_statuses in these_statuses.items():
+                    # get last statuses for this tag type
+                    last_tag_statuses = last_statuses.get(tag_type, {})
+                    # iterate through previously open items for this tag type
+                    for item in last_tag_statuses.get("open", []):
+                        # if this item is now has a delivered status
+                        # mark it as delivered
+                        if item in these_tag_statuses.get("delivered", []):
+                            delivered_items.append(
+                                {
+                                    "request_id": request_id,
+                                    "type": tag_type,
+                                    "item": item,
+                                    "snapshot_date": record["Snapshot Date"],
+                                    "last_modified": record["Last Modified"],
+                                }
+                            )
+                last_statuses = these_statuses
+        return delivered_items
+
+    def run(self, event, context):
+        """
+        Analyze airtable snapshots to identify delivered items
+        """
+        # fetch records and group by ID
+        grouped_records = self.get_grouped_records()
+        delivered_items = self.analyze_grouped_records(grouped_records)
+        log.info(f"Found {len(delivered_items)} delivered items")
+        print(delivered_items[-1])
+        return delivered_items
+
+
+if __name__ == "__main__":
+    AnalyzeRequestSnapshots().cli()
+

--- a/core/bam_core/lib/airtable.py
+++ b/core/bam_core/lib/airtable.py
@@ -240,7 +240,7 @@ class Airtable(object):
                 request_tag_schema = item_schema.get(request_tag, None)
 
                 if not request_tag_schema:
-                    log.warning(
+                    log.debug(
                         f"Unknown request tag '{request_tag}' for field '{request_field}'"
                     )
                     continue
@@ -281,7 +281,7 @@ class Airtable(object):
                             sub_request_tag, None
                         )
                         if not sub_request_tag_schema:
-                            log.warning(
+                            log.debug(
                                 f"Unknown request tag '{sub_request_tag}' for field '{sub_request_field}'"
                             )
                             continue
@@ -341,7 +341,7 @@ class Airtable(object):
                                     )
                                 )
                                 if not sub_sub_request_tag_schema:
-                                    log.warning(
+                                    log.debug(
                                         f"Unknown request tag '{sub_sub_request_tag}' for field '{sub_sub_request_field}'"
                                     )
                                     continue

--- a/core/bam_core/lib/airtable.py
+++ b/core/bam_core/lib/airtable.py
@@ -11,6 +11,7 @@ from bam_core.constants import (
     AIRTABLE_DATETIME_FORMAT,
     PHONE_FIELD,
     ASSISTANCE_REQUESTS_TABLE_NAME,
+    FULFILLED_REQUESTS_TABLE_NAME,
     ESSENTIAL_GOODS_TABLE_NAME,
     VOLUNTEERS_TABLE_NAME,
     MESH_VIEW_NAME,
@@ -84,6 +85,10 @@ class Airtable(object):
     @property
     def assistance_requests(self) -> Table:
         return self.get_table(ASSISTANCE_REQUESTS_TABLE_NAME)
+
+    @property
+    def fulfilled_requests(self) -> Table:
+        return self.get_table(FULFILLED_REQUESTS_TABLE_NAME)
 
     @property
     def essential_goods(self) -> Table:

--- a/core/tests/test_email.py
+++ b/core/tests/test_email.py
@@ -227,6 +227,7 @@ def test_dot_col():
     result = format_email(email)
     assert result["email"] == "test@gmail.com"
 
+
 def test_dot_comp():
     email = "test@gmail.comp"
     result = format_email(email)

--- a/functions/packages/cron/daily/__main__.py
+++ b/functions/packages/cron/daily/__main__.py
@@ -2,6 +2,7 @@ from bam_core.functions.base import Function
 from bam_core.functions.dedupe_airtable_views import DedupeAirtableViews
 from bam_core.functions.update_mailjet_lists import UpdateMailjetLists
 from bam_core.functions.snapshot_airtable_views import SnapshotAirtableViews
+from bam_core.functions.analyze_fulfilled_requests import AnalyzeFulfilledRequests
 
 
 def main(event, context):
@@ -11,6 +12,7 @@ def main(event, context):
         DedupeAirtableViews,
         UpdateMailjetLists,
         SnapshotAirtableViews,
+        AnalyzeFulfilledRequests
     )
 
 

--- a/functions/packages/cron/daily/__main__.py
+++ b/functions/packages/cron/daily/__main__.py
@@ -2,7 +2,9 @@ from bam_core.functions.base import Function
 from bam_core.functions.dedupe_airtable_views import DedupeAirtableViews
 from bam_core.functions.update_mailjet_lists import UpdateMailjetLists
 from bam_core.functions.snapshot_airtable_views import SnapshotAirtableViews
-from bam_core.functions.analyze_fulfilled_requests import AnalyzeFulfilledRequests
+from bam_core.functions.analyze_fulfilled_requests import (
+    AnalyzeFulfilledRequests,
+)
 
 
 def main(event, context):
@@ -12,7 +14,7 @@ def main(event, context):
         DedupeAirtableViews,
         UpdateMailjetLists,
         SnapshotAirtableViews,
-        AnalyzeFulfilledRequests
+        AnalyzeFulfilledRequests,
     )
 
 


### PR DESCRIPTION
This PR builds off the work in https://github.com/bushwickayudamutua/bam-automation/pull/3 and https://github.com/bushwickayudamutua/bam-automation/pull/1 to add a function which is capable of identifying when assistance requests are fulfilled by analyzing daily snapshots of our data. It then writes that data back to airtable which powers a dashboard for tracking # of requests fulfilled by distro and average wait times.