### PR TITLE
Update timeout eg requests to work on multiple fields

### DIFF
--- a/core/bam_core/constants.py
+++ b/core/bam_core/constants.py
@@ -462,7 +462,7 @@ EG_VIEWS = [
         name="Essential Goods: Pet Food",
         status_field_name="Essential Goods Requests Status",
         timeout_flag_value="Pet Food Timeout",
-    )
+    ),
 ]
 
 FURNITURE_VIEWS = [

--- a/core/bam_core/functions/consolidate_eg_requests.py
+++ b/core/bam_core/functions/consolidate_eg_requests.py
@@ -41,7 +41,7 @@ class ConsolidateEssentialGoodsRequests(Function):
         * a `REQUEST_FIELD`
             - (Either `eg`, `kitchen`, `furniture`)
         * an `REQUEST_VALUE` item
-            - (eg `Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴产品`)
+            - (eg `Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴用品`)
         * a `SOURCE_VIEW`, or the associated view of "open" requests for this item
             - (eg `Essential Goods: Soap & Shower Products`)
         * a list of `TARGET_VIEWS`, or other views of "open" requests
@@ -67,7 +67,7 @@ class ConsolidateEssentialGoodsRequests(Function):
             "-r",
             "--request-value",
             dest="REQUEST_VALUE",
-            help="The request to consolidate",
+            help="The request to consolidate. E.g. 'Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴用品'",
             required=True,
         )
         self.parser.add_argument(

--- a/core/bam_core/functions/consolidate_eg_requests.py
+++ b/core/bam_core/functions/consolidate_eg_requests.py
@@ -24,14 +24,14 @@ BASE_VIEW_FIELDS = [PHONE_FIELD]
 
 # handling for request field parameter
 REQUEST_SCHEMA_MAP = {
-    'eg': EG_REQUESTS_SCHEMA,
-    'kitchen': KITCHEN_REQUESTS_SCHEMA,
-    'furniture': FURNITURE_REQUESTS_SCHEMA,
+    "eg": EG_REQUESTS_SCHEMA,
+    "kitchen": KITCHEN_REQUESTS_SCHEMA,
+    "furniture": FURNITURE_REQUESTS_SCHEMA,
 }
 REQUEST_FIELD_MAP = {
-    'eg': EG_REQUESTS_FIELD,
-    'kitchen': KITCHEN_REQUESTS_FIELD,
-    'furniture': FURNITURE_REQUESTS_FIELD,
+    "eg": EG_REQUESTS_FIELD,
+    "kitchen": KITCHEN_REQUESTS_FIELD,
+    "furniture": FURNITURE_REQUESTS_FIELD,
 }
 
 

--- a/core/bam_core/functions/consolidate_eg_requests.py
+++ b/core/bam_core/functions/consolidate_eg_requests.py
@@ -58,24 +58,28 @@ class ConsolidateEssentialGoodsRequests(Function):
     def add_options(self):
         self.parser.add_argument(
             "-f",
+            "--request-field",
             dest="REQUEST_FIELD",
             help="The field to consider for consolidation. Either 'eg', 'kitchen', or 'furniture'",
             default="eg",
         )
         self.parser.add_argument(
             "-r",
+            "--request-value",
             dest="REQUEST_VALUE",
             help="The request to consolidate",
             required=True,
         )
         self.parser.add_argument(
             "-s",
+            "--source-view",
             dest="SOURCE_VIEW",
             help="The source view to consolidate requests from",
             required=True,
         )
         self.parser.add_argument(
             "-t",
+            "--target-views",
             dest="TARGET_VIEWS",
             help="The target view to consolidate requests to",
             nargs="+",
@@ -83,6 +87,7 @@ class ConsolidateEssentialGoodsRequests(Function):
         )
         self.parser.add_argument(
             "-d",
+            "--dry-run",
             dest="DRY_RUN",
             help="If true, update operations will not be performed.",
             action="store_true",

--- a/core/bam_core/functions/timeout_eg_requests.py
+++ b/core/bam_core/functions/timeout_eg_requests.py
@@ -38,27 +38,36 @@ REQUEST_FIELD_MAP = {
 
 class TimeoutEssentialGoodsRequests(Function):
     """
-    For all records that have an `ESSENTIAL_GOODS_REQUEST`, add a "timeout" status to any
-    unfulfilled records for phone numbers which have at least one fulfilled request.
+    Given:
+        * a `REQUEST_FIELD`
+            - (Either `eg`, `kitchen`, `furniture`)
+        * a `REQUEST_VALUE` item
+            - (eg `Jabón & Productos de baño / Soap & Shower Products / 肥皂和淋浴产品`)
+
+    For all records that have an `REQUEST_VALUE` in the `REQUEST_FIELD`, add an associated "timeout" status to any
+    unfulfilled records for phone numbers which have at least one later fulfilled request.
     """
 
     def add_options(self):
         self.parser.add_argument(
             "-f",
+            "--request-field",
             dest="REQUEST_FIELD",
-            help="The field to consider for consolidation. Either 'eg', 'kitchen', or 'furniture'",
+            help="The field to consider for timing out. Either 'eg', 'kitchen', or 'furniture'",
             default="eg",
         )
         self.parser.add_argument(
             "-r",
+            "--request-value",
             dest="REQUEST_VALUE",
-            help="The request to consolidate",
+            help="The request to timeout",
             required=True,
         )
         self.parser.add_argument(
             "-d",
+            "--dry-run",
             dest="DRY_RUN",
-            help="If true, update operations will not be performed.",
+            help="If true, view which timeouts would be added without actually adding them.",
             action="store_true",
             default=False,
         )

--- a/core/bam_core/functions/timeout_eg_requests.py
+++ b/core/bam_core/functions/timeout_eg_requests.py
@@ -6,17 +6,34 @@ from typing import List, Dict, Any
 from pyairtable import formulas
 
 from .base import Function
+from bam_core.utils.etc import to_list
 from bam_core.constants import (
     EG_REQUESTS_SCHEMA,
     EG_REQUESTS_FIELD,
     EG_STATUS_FIELD,
     PHONE_FIELD,
+    KITCHEN_REQUESTS_SCHEMA,
+    FURNITURE_REQUESTS_SCHEMA,
+    KITCHEN_REQUESTS_FIELD,
+    FURNITURE_REQUESTS_FIELD,
 )
 
 log = logging.getLogger(__name__)
 
 # fields to request per view
-VIEW_FIELDS = [PHONE_FIELD, EG_REQUESTS_FIELD, EG_STATUS_FIELD]
+VIEW_FIELDS = [PHONE_FIELD, EG_STATUS_FIELD]
+
+# handling for request field parameter
+REQUEST_SCHEMA_MAP = {
+    "eg": EG_REQUESTS_SCHEMA,
+    "kitchen": KITCHEN_REQUESTS_SCHEMA,
+    "furniture": FURNITURE_REQUESTS_SCHEMA,
+}
+REQUEST_FIELD_MAP = {
+    "eg": EG_REQUESTS_FIELD,
+    "kitchen": KITCHEN_REQUESTS_FIELD,
+    "furniture": FURNITURE_REQUESTS_FIELD,
+}
 
 
 class TimeoutEssentialGoodsRequests(Function):
@@ -27,8 +44,14 @@ class TimeoutEssentialGoodsRequests(Function):
 
     def add_options(self):
         self.parser.add_argument(
+            "-f",
+            dest="REQUEST_FIELD",
+            help="The field to consider for consolidation. Either 'eg', 'kitchen', or 'furniture'",
+            default="eg",
+        )
+        self.parser.add_argument(
             "-r",
-            dest="ESSENTIAL_GOODS_REQUEST",
+            dest="REQUEST_VALUE",
             help="The request to consolidate",
             required=True,
         )
@@ -53,19 +76,27 @@ class TimeoutEssentialGoodsRequests(Function):
                 traceback.print_exc()
 
     def timeout_requests(
-        self, request: str, timeout_tag: str, delivered_tag: str, dry_run: bool
+        self,
+        request_value: str,
+        request_field: str,
+        status_field: str,
+        timeout_tags: List[str],
+        delivered_tags: List[str],
+        dry_run: bool,
     ) -> Counter:
         """
         For phone numbers which have at least one fulfilled request,
         timeout all unfulfilled requests submitted before the latest
         fulfilled request.
         """
+
         # get matching requests
         request_records = self.airtable.get_phone_number_to_requests_lookup(
             formula=formulas.FIND(
-                formulas.STR_VALUE(request), formulas.FIELD(EG_REQUESTS_FIELD)
+                formulas.STR_VALUE(request_value),
+                formulas.FIELD(request_field),
             ),
-            fields=VIEW_FIELDS,
+            fields=VIEW_FIELDS + [request_field, status_field],
         )
         stats = Counter()
         for phone_number, records in request_records.items():
@@ -77,17 +108,15 @@ class TimeoutEssentialGoodsRequests(Function):
             latest_delivered_request_created_time = None
             unfulfilled_requests = []
             for record in records:
-                statuses = record.get(EG_STATUS_FIELD, [])
-                if delivered_tag in statuses:
+                created_at = record["createdTime"]
+                statuses = record.get(status_field, [])
+                if any([d in statuses for d in delivered_tags]):
                     if (
                         latest_delivered_request_created_time is None
-                        or record["createdTime"]
-                        > latest_delivered_request_created_time
+                        or created_at > latest_delivered_request_created_time
                     ):
-                        latest_delivered_request_created_time = record[
-                            "createdTime"
-                        ]
-                elif timeout_tag not in statuses:
+                        latest_delivered_request_created_time = created_at
+                elif any([t not in statuses for t in timeout_tags]):
                     # build up list of unfulfilled requests to timeout
                     unfulfilled_requests.append(record)
 
@@ -99,36 +128,56 @@ class TimeoutEssentialGoodsRequests(Function):
                 continue
 
             for record in unfulfilled_requests:
+                record_id = record["id"]
                 created_at = record["createdTime"]
+                phone_number = record["Phone Number"]
                 if created_at < latest_delivered_request_created_time:
-                    statuses = record.get(EG_STATUS_FIELD, [])
-                    statuses.append(timeout_tag)
-                    stats["timedout_requests"] += 1
-                    log.info(
-                        f"Adding {timeout_tag} to: {created_at} for phone number: {record['Phone Number']}"
+                    statuses = list(
+                        set(record.get(status_field, []) + timeout_tags)
                     )
+                    stats["timedout_requests"] += 1
+                    msg = (
+                        f"{'Adding' if dry_run else 'Would add'}"
+                        f" {','.join(timeout_tags)} to: {record_id} for phone number: {phone_number}"
+                    )
+                    log.info(msg)
                     self.update_record(
-                        record["id"], {EG_STATUS_FIELD: statuses}, dry_run
+                        record_id, {status_field: statuses}, dry_run
                     )
         return dict(stats)
 
     def run(self, event, context):
         # validate the provided request
-        request = event["ESSENTIAL_GOODS_REQUEST"]
-        if request not in EG_REQUESTS_SCHEMA["items"]:
+        request_field_shorthand = event["REQUEST_FIELD"].strip()
+        if request_field_shorthand not in REQUEST_SCHEMA_MAP:
             raise ValueError(
-                f"Invalid ESSENTIAL_GOODS_REQUEST: {request}. Choose from: {EG_REQUESTS_SCHEMA['items'].keys()}"
+                f"Invalid REQUEST_FIELD: {request_field_shorthand}. Choose from: {REQUEST_SCHEMA_MAP.keys()}"
+            )
+
+        request_schema = REQUEST_SCHEMA_MAP[request_field_shorthand]
+        request_field = REQUEST_FIELD_MAP[request_field_shorthand]
+        request_value = event["REQUEST_VALUE"].strip()
+
+        if request_value not in request_schema["items"]:
+            raise ValueError(
+                f"Invalid {request_field_shorthand} request: '{request_value}. Choose from: {request_schema.keys()}"
             )
 
         # get the timeout flag from the schema
-        timeout_tag = EG_REQUESTS_SCHEMA["items"][request]["timeout"]
-        delivered_tag = EG_REQUESTS_SCHEMA["items"][request]["delivered"]
+        timeout_tags = to_list(
+            request_schema["items"][request_value]["timeout"]
+        )
+        delivered_tags = to_list(
+            request_schema["items"][request_value]["delivered"]
+        )
 
         # timeout requests for phone numbers with >= 1 fulfilled request
         timeout_stats = self.timeout_requests(
-            request=request,
-            timeout_tag=timeout_tag,
-            delivered_tag=delivered_tag,
+            request_value=request_value,
+            request_field=request_field,
+            status_field=EG_STATUS_FIELD,
+            timeout_tags=timeout_tags,
+            delivered_tags=delivered_tags,
             dry_run=bool(event.get("DRY_RUN", False)),
         )
         log.info("Timeout process finished with stats:\n")

--- a/core/bam_core/lib/airtable.py
+++ b/core/bam_core/lib/airtable.py
@@ -17,7 +17,7 @@ from bam_core.constants import (
     MESH_VIEW_NAME,
     REQUESTS_SCHEMA,
     REQUEST_FIELDS,
-    OLD_REQUEST_TAGS
+    OLD_REQUEST_TAGS,
 )
 
 
@@ -284,7 +284,9 @@ class Airtable(object):
                     sub_status_tags = record.get(sub_status_field, [])
 
                     for sub_request_tag in sub_request_tags:
-                        sub_request_tag = OLD_REQUEST_TAGS.get(sub_request_tag, sub_request_tag)
+                        sub_request_tag = OLD_REQUEST_TAGS.get(
+                            sub_request_tag, sub_request_tag
+                        )
                         sub_request_tag_schema = sub_item_schema["items"].get(
                             sub_request_tag, None
                         )
@@ -343,7 +345,9 @@ class Airtable(object):
                             )
 
                             for sub_sub_request_tag in sub_sub_request_tags:
-                                sub_sub_request_tag = OLD_REQUEST_TAGS.get(sub_sub_request_tag, sub_sub_request_tag)
+                                sub_sub_request_tag = OLD_REQUEST_TAGS.get(
+                                    sub_sub_request_tag, sub_sub_request_tag
+                                )
                                 sub_sub_request_tag_schema = (
                                     sub_sub_item_schema["items"].get(
                                         sub_sub_request_tag, None

--- a/core/bam_core/lib/mailjet.py
+++ b/core/bam_core/lib/mailjet.py
@@ -13,7 +13,7 @@ class Mailjet(object):
         "All Contacts": 10332279,
         "Families": 10331737,
         "Volunteers": 10331731,
-        "Open Collective Donors": 10428762
+        "Open Collective Donors": 10428762,
     }
 
     ACTION_ADD = "addnoforce"

--- a/core/bam_core/lib/nyc_planning_labs.py
+++ b/core/bam_core/lib/nyc_planning_labs.py
@@ -26,5 +26,8 @@ class NycPlanningLabs(object):
             response = self.session.get(url, params=params)
             response.raise_for_status()
             return response.json()
-        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError)  as e:
+        except (
+            requests.exceptions.HTTPError,
+            requests.exceptions.ConnectionError,
+        ) as e:
             return {"error": str(e)}

--- a/core/scripts/upload_mailjet_list.py
+++ b/core/scripts/upload_mailjet_list.py
@@ -10,13 +10,21 @@ mj = Mailjet()
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(description="Upload a list of emails to Mailjet")
+    parser = argparse.ArgumentParser(
+        description="Upload a list of emails to Mailjet"
+    )
     parser.add_argument(
-        "-l", "--list-names", nargs="+", help="The names of the lists to upload to"
+        "-l",
+        "--list-names",
+        nargs="+",
+        help="The names of the lists to upload to",
     )
     parser.add_argument("-c", "--csv", help="The csv file to upload")
     parser.add_argument(
-        "-e", "--email", default="email", help="The column name of the email addresses"
+        "-e",
+        "--email",
+        default="email",
+        help="The column name of the email addresses",
     )
     parser.add_argument(
         "-d",
@@ -60,7 +68,9 @@ def main():
                 if prop in properties:
                     properties[prop] = properties[prop].lower() == "true"
             for list_name in args.list_names:
-                log.info(f"Adding {email} to {list_name} with properties: {properties}")
+                log.info(
+                    f"Adding {email} to {list_name} with properties: {properties}"
+                )
                 if not args.dry_run:
                     mj.add_contact_to_list(email, list_name, **properties)
             emails.add(email)

--- a/core/tests/test_email.py
+++ b/core/tests/test_email.py
@@ -233,10 +233,12 @@ def test_dot_comp():
     result = format_email(email)
     assert result["email"] == "test@gmail.com"
 
+
 def test_gomail_dot_com():
     email = "test@gomail.comp"
     result = format_email(email)
     assert result["email"] == "test@gmail.com"
+
 
 def test_double_dot_com():
     email = "test@gmail.com.com"


### PR DESCRIPTION
This follows changes in https://github.com/bushwickayudamutua/bam-automation/pull/8 to make it possible to use the `timeout_eq_requests` on Kitchen and Furniture requests.

Here's an example run on the command line:

```bash
$ python -m bam_core.functions.timeout_eg_requests -f kitchen -r 'Platos / Plates / 盤子' -d
[WARNING] - 08:57:30 -> Running in DRY_RUN mode. No records will be updated.
[INFO] - 08:57:30 -> Fetching records for 'Which Kitchen Items' = 'Platos / Plates / 盤子'
[INFO] - 08:57:40 -> Would add 'Plates Timeout' to the 'Essential Goods Requests Status' field for '(555) 555-1234' (created_at: 2024-09-03 20:31:26)
[INFO] - 08:57:40 -> Would add 'Plates Timeout' to the 'Essential Goods Requests Status' field for '(666) 666-1234' (created_at: 2024-09-01 13:40:56)
[INFO] - 08:57:40 -> Would add 'Plates Timeout' to the 'Essential Goods Requests Status' field for '(777) 777-1234' (created_at: 2024-09-01 13:40:56)
[INFO] - 08:57:40 -> Finished!
3 unfulfilled requests for 'Platos / Plates / 盤子' would have been timedout by adding 'Plates Timeout' to the 'Essential Goods Requests Status' field.
```