### PR TITLE
Fix GitHub Actions cache error in analyze-fulfilled-requests workflow

### DIFF
--- a/.github/workflows/fx-analyze-fulfilled-requests.yml
+++ b/.github/workflows/fx-analyze-fulfilled-requests.yml
@@ -14,11 +14,13 @@ jobs:
   analyze_fulfilled_requests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: 'pip'
+          cache-dependency-path: |
+            core/pyproject.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools


### PR DESCRIPTION
- Update actions/checkout from v3 to v4
- Update actions/setup-python from v3 to v5
- Add explicit cache-dependency-path for better cache handling
- Resolves "Cache service responded with 400" error

