### PR TITLE
Fix TypeError in retry decorator exception handling

### DIFF
--- a/core/bam_core/utils/etc.py
+++ b/core/bam_core/utils/etc.py
@@ -108,7 +108,7 @@ def retry(
             while attempt < times:
                 try:
                     return func(*args, **kwargs)
-                except exceptions as e:
+                except tuple(exceptions) as e:
                     attempt += 1
                     wait_time = wait * (backoff**attempt)
                     log.warning(


### PR DESCRIPTION
## Summary
- Fixed TypeError in the retry decorator that was causing GitHub Actions workflow failures
- Converted exceptions list to tuple for proper Python exception handling
- Resolves the issue where analyze_fulfilled_requests would fail when encountering Google Sheets API errors

## Problem
The retry decorator in `core/bam_core/utils/etc.py` was attempting to catch exceptions using a list directly in the except clause, which Python doesn't allow. This caused the error:
```
TypeError: catching classes that do not inherit from BaseException is not allowed
```

## Solution
Changed line 111 in `etc.py` from:
```python
except exceptions as e:
```
to:
```python
except tuple(exceptions) as e:
```

This properly converts the list of exceptions to a tuple, which Python accepts in except clauses.

## Test plan
- [x] The fix allows the retry decorator to properly catch and retry on exceptions
- [ ] GitHub Actions workflow should pass without the TypeError
- [ ] Google Sheets API errors will be properly retried according to the decorator settings

🤖 Generated with [Claude Code](https://claude.ai/code)