### PR TITLE
remove unversioned pydantic-core dependency

### DIFF
--- a/functions/build.sh
+++ b/functions/build.sh
@@ -18,6 +18,6 @@ pip install --target ./virtualenv/lib/python3.11/site-packages ./core
 
 # Reinstall binary packages for Linux platform (this overwrites the macOS versions)
 pip install --platform manylinux2014_x86_64 --only-binary=:all: --target ./virtualenv/lib/python3.11/site-packages --upgrade --force-reinstall --no-deps \
-    pydantic pydantic-core email-validator charset-normalizer cryptography cffi
+    pydantic pydantic-core==2.46.4 email-validator charset-normalizer cryptography cffi
 
 echo "Build complete for Linux x86_64"


### PR DESCRIPTION
I originally tried just removing the explicit `pydantic-core` install entirely. This seemed to work, but given that there's a `--no-deps` flag here and that I only tested in dry-run mode, I figured this approach was a bit safer. Beginning to wonder about how sustainable using DO functions is (as opposed to API endpoints or something similar), but that's a bigger conversation