### PR TITLE
bump API Debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile is for running the automation API in ./app
-FROM python:3.11.4-buster
+FROM python:3.11.4-bullseye
 
 # set env
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Buster LTS expired two years ago, and trying to build a container from scratch with this Dockerfile doesn't seem to work anymore.