### PR TITLE
Updates to automation + migration

### DIFF
--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -8,6 +8,7 @@ const countTable = base.getTable('Fulfilled Request Count');
 
 const countCols = countTable.fields;
 let allCounts = null;
+const dateRecordPromises = new Map();
 
 async function getAllCounts() {
   if (allCounts === null) {
@@ -17,19 +18,29 @@ async function getAllCounts() {
 }
 
 async function findOrCreateCountRecord(date) {
-  const counts = await getAllCounts();
-  for (const count of counts) {
-    if (count.getCellValue('Date') === date) return count;
+  if (date == null) return null;
+
+  if (!dateRecordPromises.has(date)) {
+    dateRecordPromises.set(date, (async () => {
+      const counts = await getAllCounts();
+      for (const count of counts) {
+        if (count.getCellValue('Date') === date) return count;
+      }
+
+      const recId = await countTable.createRecordAsync({ 'Date': date });
+      const rec = await countTable.selectRecordAsync(recId, { fields: countCols });
+      if (rec === null) throw "Airtable is broken";
+      counts.push(rec);
+      return rec;
+    })());
   }
 
-  const recId = await countTable.createRecordAsync({ 'Date': date });
-  const rec = await countTable.selectRecordAsync(recId, { fields: countCols });
-  if (rec === null) throw "Airtable is broken";
-  counts.push(rec);
-  return rec;
+  return dateRecordPromises.get(date);
 }
 
 async function processRequests(table, reqIds, columnOverwrites) {
+  if (!reqIds?.length) return;
+
   const groups = {};
 
   const reqs = (await table.selectRecordsAsync({ recordIds: reqIds, fields: [
@@ -39,6 +50,7 @@ async function processRequests(table, reqIds, columnOverwrites) {
   ] })).records;
   for (const req of reqs) {
     const date = req.getCellValue('Status Last Updated At');
+    if (date == null) continue;
 
     groups[date] ??= [];
     groups[date].push(req);
@@ -51,19 +63,23 @@ async function processRequests(table, reqIds, columnOverwrites) {
   for (const [date, reqs] of Object.entries(groups)) {
     const fields = {};
     const countRec = await findOrCreateCountRecord(date);
+    if (countRec == null) continue;
 
     for (const req of reqs) {
       const reqStatus = req.getCellValue('Status').name;
       if (reqStatus === 'Delivered') {
         const reqType = req.getCellValue('Type').name;
         const countCol = getCountCol(reqType);
+        if (!countCol) continue;
 
         fields[countCol] ??= countRec.getCellValue(countCol);
         fields[countCol]++;
       }
     }
 
-    await countTable.updateRecordAsync(countRec, fields);
+    if (Object.keys(fields).length) {
+      await countTable.updateRecordAsync(countRec, fields);
+    }
 
     for (let idx = 0; idx < reqs.length; idx += 50) {
       await table.deleteRecordsAsync(reqs.slice(idx, idx + 50));
@@ -84,6 +100,7 @@ async function processMesh(table, reqIds) {
   ] })).records;
   for (const req of reqs) {
     const date = req.getCellValue('Status Last Updated At');
+    if (date == null) continue;
 
     groups[date] ??= [];
     groups[date].push(req);
@@ -92,6 +109,7 @@ async function processMesh(table, reqIds) {
   for (const [date, reqs] of Object.entries(groups)) {
     const fields = {};
     const countRec = await findOrCreateCountRecord(date);
+    if (countRec == null) continue;
     const countedPhones = new Set();
 
     for (const req of reqs) {
@@ -107,7 +125,9 @@ async function processMesh(table, reqIds) {
       fields[countCol]++;
     }
 
-    await countTable.updateRecordAsync(countRec, fields);
+    if (Object.keys(fields).length) {
+      await countTable.updateRecordAsync(countRec, fields);
+    }
 
     // Delete records in group in pages of 50
     for (let idx = 0; idx < reqs.length; idx += 50) {

--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -1,7 +1,8 @@
-const { requestIds, ssRequestIds, meshRequestIds } = input.config();
+const { requestIds, furnRequestIds, ssRequestIds, meshRequestIds } = input.config();
 
 // Retrieve tables
 const reqTable = base.getTable('Requests');
+const furnReqTable = base.getTable('Furniture Requests');
 const ssReqTable = base.getTable('Social Service Requests');
 const meshTable = base.getTable('Mesh Requests');
 const countTable = base.getTable('Fulfilled Request Count');
@@ -138,6 +139,7 @@ async function processMesh(table, reqIds) {
 
 await Promise.all([
   processRequests(reqTable, requestIds, { }),
+  processRequests(furnReqTable, furnRequestIds, { }),
   processRequests(ssReqTable, ssRequestIds, { }),
   processMesh(meshTable, meshRequestIds),
 ]);

--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -8,7 +8,7 @@ const meshTable = base.getTable('Mesh Requests');
 const countTable = base.getTable('Fulfilled Request Count');
 
 const countCols = countTable.fields;
-let allCounts = null;
+const allCounts = (await countTable.selectRecordsAsync({ fields: countCols })).records;
 const dateRecordPromises = new Map();
 
 function dateKey(value) {
@@ -31,28 +31,19 @@ function dateKey(value) {
   return toLocalDay(parsed);
 }
 
-async function getAllCounts() {
-  if (allCounts === null) {
-    allCounts = (await countTable.selectRecordsAsync({ fields: countCols })).records;
-  }
-  return allCounts;
-}
-
 async function findOrCreateCountRecord(date) {
   const key = dateKey(date);
-  if (key == null) return null;
 
   if (!dateRecordPromises.has(key)) {
     dateRecordPromises.set(key, (async () => {
-      const counts = await getAllCounts();
-      for (const count of counts) {
+      for (const count of allCounts) {
         if (dateKey(count.getCellValue('Date')) === key) return count;
       }
 
       const recId = await countTable.createRecordAsync({ Date: key });
       const rec = await countTable.selectRecordAsync(recId, { fields: countCols });
       if (rec === null) throw "Airtable is broken";
-      counts.push(rec);
+      allCounts.push(rec);
       return rec;
     })());
   }
@@ -72,7 +63,6 @@ async function processRequests(table, reqIds, columnOverwrites) {
   ] })).records;
   for (const req of reqs) {
     const date = dateKey(req.getCellValue('Status Last Updated At'));
-    if (date == null) continue;
 
     groups[date] ??= [];
     groups[date].push(req);
@@ -85,7 +75,6 @@ async function processRequests(table, reqIds, columnOverwrites) {
   for (const [date, reqs] of Object.entries(groups)) {
     const fields = {};
     const countRec = await findOrCreateCountRecord(date);
-    if (countRec == null) continue;
 
     for (const req of reqs) {
       const reqStatus = req.getCellValue('Status').name;
@@ -122,7 +111,6 @@ async function processMesh(table, reqIds) {
   ] })).records;
   for (const req of reqs) {
     const date = dateKey(req.getCellValue('Status Last Updated At'));
-    if (date == null) continue;
 
     groups[date] ??= [];
     groups[date].push(req);
@@ -131,7 +119,6 @@ async function processMesh(table, reqIds) {
   for (const [date, reqs] of Object.entries(groups)) {
     const fields = {};
     const countRec = await findOrCreateCountRecord(date);
-    if (countRec == null) continue;
     const countedPhones = new Set();
 
     for (const req of reqs) {

--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -13,8 +13,14 @@ const dateRecordPromises = new Map();
 
 function dateKey(value) {
   if (value == null) return null;
+  const toLocalDay = (d) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
   if (value instanceof Date) {
-    return value.toISOString().slice(0, 10);
+    return toLocalDay(value);
   }
   const text = String(value).trim();
   if (/^\d{4}-\d{2}-\d{2}/.test(text)) {
@@ -22,7 +28,7 @@ function dateKey(value) {
   }
   const parsed = new Date(text);
   if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toISOString().slice(0, 10);
+  return toLocalDay(parsed);
 }
 
 async function getAllCounts() {

--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -1,27 +1,35 @@
-const { requestIds, ssRequestIds } = input.config();
+const { requestIds, ssRequestIds, meshRequestIds } = input.config();
 
 // Retrieve tables
 const reqTable = base.getTable('Requests');
 const ssReqTable = base.getTable('Social Service Requests');
+const meshTable = base.getTable('Mesh Requests');
 const countTable = base.getTable('Fulfilled Request Count');
 
-async function processRequests(table, reqIds, columnOverwrites) {
-  // Step 1: pull all count records, define find-or-create util
-  const countCols = countTable.fields;
-  const allCounts = (await countTable.selectRecordsAsync({ fields: countCols })).records;
+const countCols = countTable.fields;
+let allCounts = null;
 
-  async function findOrCreateCountRecord(date) {
-    for (const count of allCounts) {
-      if (count.getCellValue('Date') === date) return count;
-    }
-  
-    const recId = await countTable.createRecordAsync({ 'Date': date });
-    const rec = await countTable.selectRecordAsync(recId, { fields: countCols });
-    if (rec === null) throw "Airtable is broken";
-    return rec;
+async function getAllCounts() {
+  if (allCounts === null) {
+    allCounts = (await countTable.selectRecordsAsync({ fields: countCols })).records;
+  }
+  return allCounts;
+}
+
+async function findOrCreateCountRecord(date) {
+  const counts = await getAllCounts();
+  for (const count of counts) {
+    if (count.getCellValue('Date') === date) return count;
   }
 
-  // Step 2: group requests by date and type
+  const recId = await countTable.createRecordAsync({ 'Date': date });
+  const rec = await countTable.selectRecordAsync(recId, { fields: countCols });
+  if (rec === null) throw "Airtable is broken";
+  counts.push(rec);
+  return rec;
+}
+
+async function processRequests(table, reqIds, columnOverwrites) {
   const groups = {};
 
   const reqs = (await table.selectRecordsAsync({ recordIds: reqIds, fields: [
@@ -36,9 +44,6 @@ async function processRequests(table, reqIds, columnOverwrites) {
     groups[date].push(req);
   }
 
-  // Step 3: process each group 
-
-  // Helper function to convert request type to counter column
   function getCountCol(reqType) {
     return columnOverwrites[reqType] ?? reqType.split(' / ')[1];
   }
@@ -58,7 +63,50 @@ async function processRequests(table, reqIds, columnOverwrites) {
       }
     }
 
-    // Update counter
+    await countTable.updateRecordAsync(countRec, fields);
+
+    for (let idx = 0; idx < reqs.length; idx += 50) {
+      await table.deleteRecordsAsync(reqs.slice(idx, idx + 50));
+    }
+  }
+}
+
+async function processMesh(table, reqIds) {
+  if (!reqIds?.length) return;
+
+  const countCol = 'Low-Cost Home Internet';
+  const groups = {};
+
+  const reqs = (await table.selectRecordsAsync({ recordIds: reqIds, fields: [
+    'Status',
+    'Status Last Updated At',
+    'Phone Number (from Household)',
+  ] })).records;
+  for (const req of reqs) {
+    const date = req.getCellValue('Status Last Updated At');
+
+    groups[date] ??= [];
+    groups[date].push(req);
+  }
+
+  for (const [date, reqs] of Object.entries(groups)) {
+    const fields = {};
+    const countRec = await findOrCreateCountRecord(date);
+    const countedPhones = new Set();
+
+    for (const req of reqs) {
+      const reqStatus = req.getCellValue('Status').name;
+      if (reqStatus !== 'YAY! MESH INSTALLED!') continue;
+
+      const phoneRaw = req.getCellValue('Phone Number (from Household)');
+      const phone = Array.isArray(phoneRaw) ? phoneRaw[0] : phoneRaw;
+      if (!phone || countedPhones.has(phone)) continue;
+
+      countedPhones.add(phone);
+      fields[countCol] ??= countRec.getCellValue(countCol);
+      fields[countCol]++;
+    }
+
     await countTable.updateRecordAsync(countRec, fields);
 
     // Delete records in group in pages of 50
@@ -69,27 +117,7 @@ async function processRequests(table, reqIds, columnOverwrites) {
 }
 
 await Promise.all([
-  processRequests(reqTable, requestIds, {
-    "Bastidor individual / Twin Bed Frame 單人床架": "Twin Bed Frame",
-    "Comida caliente / Hot meals / 热食": "Hot Meals",
-  }),
-  processRequests(ssReqTable, ssRequestIds, {
-    "Asistencia legal de inquilinos / Tenant legal assistance / 租戶法律協助":
-      "Tenant Legal Assistance",
-    "Asistencia con servicios escolares / Assistance with in-school services / 學校服務協助":
-      "Assistance with In-School Services",
-    "Tutoría estudiantil / Tutoring for students / 學生輔導":
-      "Tutoring for Students",
-    "Asistencia asegurando vivienda/ Securing housing / 住房協助":
-      "Assistance Securing Housing",
-    "Asistencia con seguro médico / Medical insurance support / 醫療保險協助":
-      "Medical Insurance Support",
-    "Internet de bajo costo en casa / Low-Cost Internet at home / 網絡連結協助":
-      "Low-Cost Home Internet",
-    "Asistencia con beneficios de comida / Assistance with food benefits / 食品福利協助（WIC, SNAP, P-EBT）":
-      "Assistance with Food Benefits",
-    "Asistencia para niños con discapacidad / Assistance for disabled children / 殘疾兒童協助":
-      "Assistance for Disabled Children",
-  }),
+  processRequests(reqTable, requestIds, { }),
+  processRequests(ssReqTable, ssRequestIds, { }),
+  processMesh(meshTable, meshRequestIds),
 ]);
-

--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -11,6 +11,20 @@ const countCols = countTable.fields;
 let allCounts = null;
 const dateRecordPromises = new Map();
 
+function dateKey(value) {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  const text = String(value).trim();
+  if (/^\d{4}-\d{2}-\d{2}/.test(text)) {
+    return text.slice(0, 10);
+  }
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString().slice(0, 10);
+}
+
 async function getAllCounts() {
   if (allCounts === null) {
     allCounts = (await countTable.selectRecordsAsync({ fields: countCols })).records;
@@ -19,16 +33,17 @@ async function getAllCounts() {
 }
 
 async function findOrCreateCountRecord(date) {
-  if (date == null) return null;
+  const key = dateKey(date);
+  if (key == null) return null;
 
-  if (!dateRecordPromises.has(date)) {
-    dateRecordPromises.set(date, (async () => {
+  if (!dateRecordPromises.has(key)) {
+    dateRecordPromises.set(key, (async () => {
       const counts = await getAllCounts();
       for (const count of counts) {
-        if (count.getCellValue('Date') === date) return count;
+        if (dateKey(count.getCellValue('Date')) === key) return count;
       }
 
-      const recId = await countTable.createRecordAsync({ 'Date': date });
+      const recId = await countTable.createRecordAsync({ Date: key });
       const rec = await countTable.selectRecordAsync(recId, { fields: countCols });
       if (rec === null) throw "Airtable is broken";
       counts.push(rec);
@@ -36,7 +51,7 @@ async function findOrCreateCountRecord(date) {
     })());
   }
 
-  return dateRecordPromises.get(date);
+  return dateRecordPromises.get(key);
 }
 
 async function processRequests(table, reqIds, columnOverwrites) {
@@ -50,7 +65,7 @@ async function processRequests(table, reqIds, columnOverwrites) {
     'Type',
   ] })).records;
   for (const req of reqs) {
-    const date = req.getCellValue('Status Last Updated At');
+    const date = dateKey(req.getCellValue('Status Last Updated At'));
     if (date == null) continue;
 
     groups[date] ??= [];
@@ -100,7 +115,7 @@ async function processMesh(table, reqIds) {
     'Phone Number (from Household)',
   ] })).records;
   for (const req of reqs) {
-    const date = req.getCellValue('Status Last Updated At');
+    const date = dateKey(req.getCellValue('Status Last Updated At'));
     if (date == null) continue;
 
     groups[date] ??= [];

--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -86,9 +86,9 @@ await Promise.all([
       "Medical Insurance Support",
     "Internet de bajo costo en casa / Low-Cost Internet at home / 網絡連結協助":
       "Low-Cost Home Internet",
-    "Asistencia con beneficios de comida / Assistance with food benefits / 食品福利協助 (WIC, SNAP, P-EBT)":
+    "Asistencia con beneficios de comida / Assistance with food benefits / 食品福利協助（WIC, SNAP, P-EBT）":
       "Assistance with Food Benefits",
-    "Asistencia para niños discapacitados / Assistance for disabled children / 殘疾兒童協助":
+    "Asistencia para niños con discapacidad / Assistance for disabled children / 殘疾兒童協助":
       "Assistance for Disabled Children",
   }),
 ]);

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -1,6 +1,8 @@
 const { requestIds, ssRequestIds, meshRequestIds } = input.config()
 
 async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
+    if (!recordIds?.length) return
+
     // Pull requests from table
     const requestTable = base.getTable(tableName)
     const requestsQuery = await requestTable.selectRecordsAsync({

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -1,4 +1,4 @@
-const { requestIds, ssRequestIds, meshRequestIds } = input.config()
+const { requestIds, furnRequestIds, ssRequestIds, meshRequestIds } = input.config()
 
 async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
     if (!recordIds?.length) return
@@ -64,21 +64,17 @@ const trimText = (value) => (value || '').trim()
 
 const MESH_STATUS_RANK = {
     'Open': 0,
-    'Texted about Mesh': 1,
-    'Step 1 - Interested in Mesh': 2,
+    'Contacted about Mesh': 1,
+    'Interested in Mesh': 2,
     'Needs Panorama': 3,
     'Roof Access In Process': 4,
     'Confirming Permission with Landlord': 5,
     'Roof Access Confirmed': 6,
-    'Step 2 - LOS Confirmed': 7,
-    'Step 3 - Scheduling IN-PROGRESS': 8,
+    'LOS Confirmed': 7,
+    'Scheduling IN-PROGRESS': 8,
     'Install Scheduled': 9,
-    'YAY! MESH INSTALLED!': 10,
-    'Not Interested': 11,
-    'Cannot Install - Does not have LOS': 11,
-    'NYCHA - Currently Does Not Qualify': 11,
-    'Cannot Install - No Roof Access': 11,
-    'Cannot Install - Other Reason': 11,
+    'Cannot Install': 10,
+    'YAY! MESH INSTALLED!': 11,
     'INSTALL PENDING ELDERT REPAIR': 12,
 }
 
@@ -164,6 +160,10 @@ const fromAddressBundle = (field) => (_, reqGroup) => {
 }
 
 await mergeReqs('Requests', requestIds, 'Type', {
+    'Last Requested': getLast,
+    'Legacy Date Submitted': minDate,
+})
+await mergeReqs('Furniture Requests', furnRequestIds, 'Type', {
     'Last Requested': getLast,
     Geocode: getLast,
     'Legacy Date Submitted': minDate,

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -28,9 +28,14 @@ async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
         })
         .forEach((req) => {
             const rawKey = req.getCellValue(keyField)
-            const key = typeof rawKey === 'object'
+            let key = (rawKey !== null && typeof rawKey === 'object')
                 ? rawKey.id
                 : rawKey
+            // A missing/blank key (e.g. a Mesh Request with no Building
+            // Identification Number) does not mean these records are the same
+            // household. Give each unkeyed record a unique key so it stays in
+            // its own group and is never merged with unrelated records.
+            if (key == null || key === '') key = Symbol('unkeyed')
             if (!requestGroups.has(key)) requestGroups.set(key, [])
             requestGroups.get(key).push(req)
         })

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -28,14 +28,9 @@ async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
         })
         .forEach((req) => {
             const rawKey = req.getCellValue(keyField)
-            let key = (rawKey !== null && typeof rawKey === 'object')
+            const key = typeof rawKey === 'object'
                 ? rawKey.id
                 : rawKey
-            // A missing/blank key (e.g. a Mesh Request with no Building
-            // Identification Number) does not mean these records are the same
-            // household. Give each unkeyed record a unique key so it stays in
-            // its own group and is never merged with unrelated records.
-            if (key == null || key === '') key = Symbol('unkeyed')
             if (!requestGroups.has(key)) requestGroups.set(key, [])
             requestGroups.get(key).push(req)
         })

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -1,19 +1,19 @@
-const { requestIds, ssRequestIds } = input.config()
+const { requestIds, ssRequestIds, meshRequestIds } = input.config()
 
-async function mergeReqs(tableName, recordIds, mergeFns) {
+async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
     // Pull requests from table
     const requestTable = base.getTable(tableName)
     const requestsQuery = await requestTable.selectRecordsAsync({
         recordIds,
         fields: [
-            'Type',
+            keyField,
             'Request Opened At',
             ...Object.keys(mergeFns),
         ]
     })
     const requests = [...requestsQuery.records]
 
-    // Group requests by type, sorted from oldest to newest
+    // Group requests by key, sorted from oldest to newest
     const requestGroups = new Map()
 
     requests
@@ -25,22 +25,26 @@ async function mergeReqs(tableName, recordIds, mergeFns) {
             return 0
         })
         .forEach((req) => {
-            const type = req.getCellValue('Type').id
-            if (!requestGroups.has(type)) requestGroups.set(type, [])
-            requestGroups.get(type).push(req)
+            const rawKey = req.getCellValue(keyField)
+            const key = typeof rawKey === 'object'
+                ? rawKey.id
+                : rawKey
+            if (!requestGroups.has(key)) requestGroups.set(key, [])
+            requestGroups.get(key).push(req)
         })
 
     // Merge fields according to callbacks, delete repeat requests
     for (let [, reqGroup] of requestGroups) {
         const [firstReq, ...rest] = reqGroup
 
-        await requestTable.updateRecordAsync(
-            firstReq,
-            Object.fromEntries(Object.keys(mergeFns).map((field) => {
+        const x = Object.fromEntries(Object.keys(mergeFns).map((field) => {
                 const fn = mergeFns[field]
                 const value = fn(reqGroup.map((req) => req.getCellValue(field)))
                 return [field, value]
             }))
+        console.log(x)
+        await requestTable.updateRecordAsync(
+            firstReq, x
         )
         await requestTable.deleteRecordsAsync(rest)
     }
@@ -49,18 +53,23 @@ async function mergeReqs(tableName, recordIds, mergeFns) {
 const mergeNotes = (notes) => notes.filter((note) => note !== '').join('\n')
 const getLast = (arr) => arr.pop()
 
-await mergeReqs('Requests', requestIds, {
+await mergeReqs('Requests', requestIds, 'Type', {
     'Last Requested': getLast,
     Geocode: getLast,
 })
-await mergeReqs('Social Service Requests', ssRequestIds, {
+await mergeReqs('Social Service Requests', ssRequestIds, 'Type', {
     'Last Requested': getLast,
-    'Internet Access': (iaLists) =>
-        [...new Set(iaLists.map((iaList) => iaList ?? []).flat())],
-    'Roof Accessible?': getLast,
+})
+await mergeReqs('Mesh Requests', meshRequestIds, 'Building Identification Number', {
+    'Last Requested': getLast,
+    'Internet Access': (iaLists) => {
+        const allSelectionIds = iaLists.map((iaList) => iaList ?? []).flat().map(({ id }) => id)
+        const uniqIds = [...new Set(allSelectionIds)]
+        return uniqIds.map((id) => ({ id }))
+    },
     'Street Address': getLast,
     'City, State': getLast,
     'Zip Code': getLast,
-    Geocode: getLast,
+    Address: getLast,
+    'Address Accuracy': getLast,
 })
-

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -37,31 +37,42 @@ async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
     for (let [, reqGroup] of requestGroups) {
         const [firstReq, ...rest] = reqGroup
 
-        const x = Object.fromEntries(Object.keys(mergeFns).map((field) => {
-                const fn = mergeFns[field]
-                const value = fn(reqGroup.map((req) => req.getCellValue(field)))
-                return [field, value]
-            }))
-        console.log(x)
+        const mergedFields = Object.fromEntries(Object.keys(mergeFns).map((field) => {
+            const fn = mergeFns[field]
+            const value = fn(reqGroup.map((req) => req.getCellValue(field)))
+            return [field, value]
+        }))
         await requestTable.updateRecordAsync(
-            firstReq, x
+            firstReq, mergedFields
         )
         await requestTable.deleteRecordsAsync(rest)
     }
 }
 
-const mergeNotes = (notes) => notes.filter((note) => note !== '').join('\n')
+const minDate = (dates) => {
+    const valid = dates.filter(Boolean)
+    if (!valid.length) return undefined
+    return valid.reduce((min, d) => (d < min ? d : min))
+}
 const getLast = (arr) => arr.pop()
 
 await mergeReqs('Requests', requestIds, 'Type', {
     'Last Requested': getLast,
     Geocode: getLast,
+    'Legacy Date Submitted': minDate,
 })
 await mergeReqs('Social Service Requests', ssRequestIds, 'Type', {
     'Last Requested': getLast,
+    'Legacy Date Submitted': minDate,
+    'Partner Org': (orgLists) => {
+        const allSelectionIds = orgLists.map((orgList) => orgList ?? []).flat().map(({ id }) => id)
+        const uniqIds = [...new Set(allSelectionIds)]
+        return uniqIds.map((id) => ({ id }))
+    },
 })
 await mergeReqs('Mesh Requests', meshRequestIds, 'Building Identification Number', {
     'Last Requested': getLast,
+    'Legacy Date Submitted': minDate,
     'Internet Access': (iaLists) => {
         const allSelectionIds = iaLists.map((iaList) => iaList ?? []).flat().map(({ id }) => id)
         const uniqIds = [...new Set(allSelectionIds)]

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -39,17 +39,21 @@ async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
     for (let [, reqGroup] of requestGroups) {
         const [firstReq, ...rest] = reqGroup
 
-        const mergedFields = Object.fromEntries(Object.keys(mergeFns).map((field) => {
-            const fn = mergeFns[field]
-            const value = fn(
-                reqGroup.map((req) => req.getCellValue(field)),
-                reqGroup,
-            )
-            return [field, value]
-        }))
-        await requestTable.updateRecordAsync(
-            firstReq, mergedFields
+        const mergedFields = Object.fromEntries(
+            Object.keys(mergeFns)
+                .map((field) => {
+                    const fn = mergeFns[field]
+                    const value = fn(
+                        reqGroup.map((req) => req.getCellValue(field)),
+                        reqGroup,
+                    )
+                    return [field, value]
+                })
+                .filter(([, value]) => value != null && !(Array.isArray(value) && value.length === 0))
         )
+        if (Object.keys(mergedFields).length) {
+            await requestTable.updateRecordAsync(firstReq, mergedFields)
+        }
         await requestTable.deleteRecordsAsync(rest)
     }
 }

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -33,13 +33,16 @@ async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
             requestGroups.get(key).push(req)
         })
 
-    // Merge fields according to callbacks, delete repeat requests
+    // Survivor = earliest Request Opened At
     for (let [, reqGroup] of requestGroups) {
         const [firstReq, ...rest] = reqGroup
 
         const mergedFields = Object.fromEntries(Object.keys(mergeFns).map((field) => {
             const fn = mergeFns[field]
-            const value = fn(reqGroup.map((req) => req.getCellValue(field)))
+            const value = fn(
+                reqGroup.map((req) => req.getCellValue(field)),
+                reqGroup,
+            )
             return [field, value]
         }))
         await requestTable.updateRecordAsync(
@@ -54,7 +57,109 @@ const minDate = (dates) => {
     if (!valid.length) return undefined
     return valid.reduce((min, d) => (d < min ? d : min))
 }
-const getLast = (arr) => arr.pop()
+const getLast = (arr) => arr[arr.length - 1]
+const trimText = (value) => (value || '').trim()
+
+const MESH_STATUS_RANK = {
+    'Open': 0,
+    'Texted about Mesh': 1,
+    'Step 1 - Interested in Mesh': 2,
+    'Needs Panorama': 3,
+    'Roof Access In Process': 4,
+    'Confirming Permission with Landlord': 5,
+    'Roof Access Confirmed': 6,
+    'Step 2 - LOS Confirmed': 7,
+    'Step 3 - Scheduling IN-PROGRESS': 8,
+    'Install Scheduled': 9,
+    'YAY! MESH INSTALLED!': 10,
+    'Not Interested': 11,
+    'Cannot Install - Does not have LOS': 11,
+    'NYCHA - Currently Does Not Qualify': 11,
+    'Cannot Install - No Roof Access': 11,
+    'Cannot Install - Other Reason': 11,
+    'INSTALL PENDING ELDERT REPAIR': 12,
+}
+
+const ADDRESS_ACCURACY_RANK = {
+    'Apartment': 3,
+    'Building': 2,
+    'Address Outside NY': 1,
+    'No result': 0,
+    '': 0,
+    'Invalid Address Provided': -1,
+}
+
+const maxMeshStatus = (statuses) => {
+    let best = null
+    let bestRank = -1
+    for (const status of statuses) {
+        if (!status) continue
+        const rank = MESH_STATUS_RANK[status.name] ?? -1
+        if (rank > bestRank) {
+            bestRank = rank
+            best = status
+        }
+    }
+    return best ? { id: best.id } : null
+}
+
+const pickAddressBundleIndex = (reqGroup) => {
+    let bestIdx = 0
+    let bestRank = -2
+    for (let i = 0; i < reqGroup.length; i++) {
+        const accuracy = reqGroup[i].getCellValue('Address Accuracy')
+        const rank = ADDRESS_ACCURACY_RANK[accuracy?.name ?? ''] ?? -2
+        if (rank > bestRank || (rank === bestRank && i > bestIdx)) {
+            bestRank = rank
+            bestIdx = i
+        }
+    }
+
+    const hasAddressText = (idx) =>
+        trimText(reqGroup[idx].getCellValue('Address')) ||
+        trimText(reqGroup[idx].getCellValue('Street Address'))
+
+    if (!hasAddressText(bestIdx)) {
+        for (let i = reqGroup.length - 1; i >= 0; i--) {
+            if (trimText(reqGroup[i].getCellValue('Address'))) {
+                bestIdx = i
+                break
+            }
+        }
+        if (!trimText(reqGroup[bestIdx].getCellValue('Address'))) {
+            for (let i = reqGroup.length - 1; i >= 0; i--) {
+                if (trimText(reqGroup[i].getCellValue('Street Address'))) {
+                    bestIdx = i
+                    break
+                }
+            }
+        }
+    }
+
+    return bestIdx
+}
+
+let addressBundleCache = { group: null, idx: 0 }
+const addressBundleIndex = (reqGroup) => {
+    if (reqGroup !== addressBundleCache.group) {
+        addressBundleCache.group = reqGroup
+        addressBundleCache.idx = pickAddressBundleIndex(reqGroup)
+    }
+    return addressBundleCache.idx
+}
+
+const fromAddressBundle = (field) => (_, reqGroup) => {
+    const idx = addressBundleIndex(reqGroup)
+    if (field === 'Address') {
+        let address = trimText(reqGroup[idx].getCellValue('Address'))
+        return address || null
+    }
+    const value = reqGroup[idx].getCellValue(field)
+    if (field === 'Address Accuracy') {
+        return value ? { id: value.id } : null
+    }
+    return value
+}
 
 await mergeReqs('Requests', requestIds, 'Type', {
     'Last Requested': getLast,
@@ -73,14 +178,15 @@ await mergeReqs('Social Service Requests', ssRequestIds, 'Type', {
 await mergeReqs('Mesh Requests', meshRequestIds, 'Building Identification Number', {
     'Last Requested': getLast,
     'Legacy Date Submitted': minDate,
+    Status: maxMeshStatus,
     'Internet Access': (iaLists) => {
         const allSelectionIds = iaLists.map((iaList) => iaList ?? []).flat().map(({ id }) => id)
         const uniqIds = [...new Set(allSelectionIds)]
         return uniqIds.map((id) => ({ id }))
     },
-    'Street Address': getLast,
-    'City, State': getLast,
-    'Zip Code': getLast,
-    Address: getLast,
-    'Address Accuracy': getLast,
+    'Street Address': fromAddressBundle('Street Address'),
+    'City, State': fromAddressBundle('City, State'),
+    'Zip Code': fromAddressBundle('Zip Code'),
+    Address: fromAddressBundle('Address'),
+    'Address Accuracy': fromAddressBundle('Address Accuracy'),
 })

--- a/automation-scripts/v2/merge-households/merge-households.js
+++ b/automation-scripts/v2/merge-households/merge-households.js
@@ -41,6 +41,10 @@ const socialServiceRequests = dedupeById(
     allHouseholds.map(h => h.getCellValue('Social Service Requests'))
 )
 
+const meshRequests = dedupeById(
+    allHouseholds.map(h => h.getCellValue('Mesh Requests'))
+)
+
 // Merges text fields without deduping — trims each entry, filters blanks, joins with newline
 const mergeText = (texts) =>
     texts
@@ -85,8 +89,9 @@ await householdTable.updateRecordAsync(survivor, {
     Notes: notes,
     Requests: requests,
     'Social Service Requests': socialServiceRequests,
-    'Needs Delivery': allHouseholds.some(h => h.getCellValue('Needs Delivery')) || null,
-    'Needs Email Outreach': allHouseholds.some(h => h.getCellValue('Needs Email Outreach')) || null,
+    'Mesh Requests': meshRequests,
+    'Needs Delivery': allHouseholds.some(h => h.getCellValue('Needs Delivery')),
+    'Needs Email Outreach': allHouseholds.some(h => h.getCellValue('Needs Email Outreach')),
 })
 
 const recordsToDelete = [newHousehold, ...otherOldHouseholds]

--- a/automation-scripts/v2/merge-households/merge-households.js
+++ b/automation-scripts/v2/merge-households/merge-households.js
@@ -70,9 +70,13 @@ const dedupeById = (items) => {
     return uniqueItems.length ? uniqueItems : undefined
 }
 
-const languages = dedupeById(
-    allHouseholds.map(h => h.getCellValue('Languages'))
-)
+const languageItems = allHouseholds.map(h => h.getCellValue('Languages'))
+const languages = dedupeById(languageItems)
+if (languages) {
+    const otherId = languageItems.flat().find(item => item?.name === 'Otro / Other / 其他語言')?.id
+    const idx = otherId ? languages.findIndex(item => item.id === otherId) : -1
+    if (idx !== -1) languages.push(languages.splice(idx, 1)[0])
+}
 
 const requests = dedupeById(
     allHouseholds.map(h => h.getCellValue('Requests'))

--- a/automation-scripts/v2/merge-households/merge-households.js
+++ b/automation-scripts/v2/merge-households/merge-households.js
@@ -14,6 +14,46 @@ const otherOldHouseholds = await Promise.all(otherOldIds.map(getHousehold))
 
 const allHouseholds = [survivor, ...otherOldHouseholds, newHousehold]
 
+const minDate = (dates) => {
+    const valid = dates.filter(Boolean)
+    if (!valid.length) return undefined
+    return valid.reduce((min, d) => (d < min ? d : min))
+}
+
+const maxDate = (dates) => {
+    const valid = dates.filter(Boolean)
+    if (!valid.length) return undefined
+    return valid.reduce((max, d) => (d > max ? d : max))
+}
+
+const legacyFirstDate = minDate(
+    allHouseholds.map(h => h.getCellValue('Legacy First Date Submitted'))
+)
+const legacyLastDate = maxDate(
+    allHouseholds.map(h => h.getCellValue('Legacy Last Date Submitted'))
+)
+const lastTexted = maxDate(allHouseholds.map(h => h.getCellValue('Last Texted')))
+const lastCalled = maxDate(allHouseholds.map(h => h.getCellValue('Last Called')))
+
+const pickAppointmentFields = (households) => {
+    const maxApptDate = maxDate(households.map(h => h.getCellValue('Appointment Date')))
+    if (!maxApptDate) return {}
+    let source = null
+    for (let i = households.length - 1; i >= 0; i--) {
+        const d = households[i].getCellValue('Appointment Date')
+        if (d && d.getTime() === maxApptDate.getTime()) {
+            source = households[i]
+            break
+        }
+    }
+    return {
+        'Appointment Date': maxApptDate,
+        'Appointment Time': source.getCellValue('Appointment Time'),
+        'Appointment Status': source.getCellValue('Appointment Status'),
+    }
+}
+const appointmentFields = pickAppointmentFields(allHouseholds)
+
 // Helper to dedupe and extract {id} from linked records or multi-select
 const dedupeById = (items) => {
     const seen = new Set()
@@ -92,6 +132,11 @@ await householdTable.updateRecordAsync(survivor, {
     'Mesh Requests': meshRequests,
     'Needs Delivery': allHouseholds.some(h => h.getCellValue('Needs Delivery')),
     'Needs Email Outreach': allHouseholds.some(h => h.getCellValue('Needs Email Outreach')),
+    ...(legacyFirstDate != null && { 'Legacy First Date Submitted': legacyFirstDate }),
+    ...(legacyLastDate != null && { 'Legacy Last Date Submitted': legacyLastDate }),
+    ...(lastTexted != null && { 'Last Texted': lastTexted }),
+    ...(lastCalled != null && { 'Last Called': lastCalled }),
+    ...appointmentFields,
 })
 
 const recordsToDelete = [newHousehold, ...otherOldHouseholds]

--- a/automation-scripts/v2/merge-households/merge-households.js
+++ b/automation-scripts/v2/merge-households/merge-households.js
@@ -78,6 +78,10 @@ const requests = dedupeById(
     allHouseholds.map(h => h.getCellValue('Requests'))
 )
 
+const furnitureRequests = dedupeById(
+    allHouseholds.map(h => h.getCellValue('Furniture Requests'))
+)
+
 const socialServiceRequests = dedupeById(
     allHouseholds.map(h => h.getCellValue('Social Service Requests'))
 )
@@ -129,6 +133,7 @@ await householdTable.updateRecordAsync(survivor, {
     "Other Languages": otherLanguages,
     Notes: notes,
     Requests: requests,
+    'Furniture Requests': furnitureRequests,
     'Social Service Requests': socialServiceRequests,
     'Mesh Requests': meshRequests,
     'Needs Delivery': allHouseholds.some(h => h.getCellValue('Needs Delivery')),

--- a/automation-scripts/v2/merge-households/merge-households.js
+++ b/automation-scripts/v2/merge-households/merge-households.js
@@ -46,6 +46,7 @@ const pickAppointmentFields = (households) => {
             break
         }
     }
+    if (!source) return {}
     return {
         'Appointment Date': maxApptDate,
         'Appointment Time': source.getCellValue('Appointment Time'),

--- a/automation-scripts/v2/merge-households/merge-households.js
+++ b/automation-scripts/v2/merge-households/merge-households.js
@@ -14,47 +14,6 @@ const otherOldHouseholds = await Promise.all(otherOldIds.map(getHousehold))
 
 const allHouseholds = [survivor, ...otherOldHouseholds, newHousehold]
 
-const minDate = (dates) => {
-    const valid = dates.filter(Boolean)
-    if (!valid.length) return undefined
-    return valid.reduce((min, d) => (d < min ? d : min))
-}
-
-const maxDate = (dates) => {
-    const valid = dates.filter(Boolean)
-    if (!valid.length) return undefined
-    return valid.reduce((max, d) => (d > max ? d : max))
-}
-
-const legacyFirstDate = minDate(
-    allHouseholds.map(h => h.getCellValue('Legacy First Date Submitted'))
-)
-const legacyLastDate = maxDate(
-    allHouseholds.map(h => h.getCellValue('Legacy Last Date Submitted'))
-)
-const lastTexted = maxDate(allHouseholds.map(h => h.getCellValue('Last Texted')))
-const lastCalled = maxDate(allHouseholds.map(h => h.getCellValue('Last Called')))
-
-const pickAppointmentFields = (households) => {
-    const maxApptDate = maxDate(households.map(h => h.getCellValue('Appointment Date')))
-    if (!maxApptDate) return {}
-    let source = null
-    for (let i = households.length - 1; i >= 0; i--) {
-        const d = households[i].getCellValue('Appointment Date')
-        if (d && d.getTime() === maxApptDate.getTime()) {
-            source = households[i]
-            break
-        }
-    }
-    if (!source) return {}
-    return {
-        'Appointment Date': maxApptDate,
-        'Appointment Time': source.getCellValue('Appointment Time'),
-        'Appointment Status': source.getCellValue('Appointment Status'),
-    }
-}
-const appointmentFields = pickAppointmentFields(allHouseholds)
-
 // Helper to dedupe and extract {id} from linked records or multi-select
 const dedupeById = (items) => {
     const seen = new Set()
@@ -142,11 +101,6 @@ await householdTable.updateRecordAsync(survivor, {
     'Mesh Requests': meshRequests,
     'Needs Delivery': allHouseholds.some(h => h.getCellValue('Needs Delivery')),
     'Needs Email Outreach': allHouseholds.some(h => h.getCellValue('Needs Email Outreach')),
-    ...(legacyFirstDate != null && { 'Legacy First Date Submitted': legacyFirstDate }),
-    ...(legacyLastDate != null && { 'Legacy Last Date Submitted': legacyLastDate }),
-    ...(lastTexted != null && { 'Last Texted': lastTexted }),
-    ...(lastCalled != null && { 'Last Called': lastCalled }),
-    ...appointmentFields,
 })
 
 const recordsToDelete = [newHousehold, ...otherOldHouseholds]

--- a/automation-scripts/v2/transform-form-submission/clean-record.js
+++ b/automation-scripts/v2/transform-form-submission/clean-record.js
@@ -24,25 +24,47 @@ const clean = async (email, phone, address, city_state, zipcode) => {
     }
 }
 
-// clean data
+const passThroughAddress = [address, city, zipCode].join(' ') || ''
+
+const setOutputs = (fields, success) => {
+    output.set('phone', fields.phone || '')
+    output.set('phone_is_invalid', fields.phone_is_invalid || false)
+    output.set('phone_is_intl', fields.phone_is_intl || false)
+    output.set('email', fields.email || '')
+    output.set('email_error', fields.email_error || '')
+    output.set('cleaned_address', fields.cleaned_address || '')
+    output.set('cleaned_address_accuracy', fields.cleaned_address_accuracy || '')
+    output.set('bin', fields.bin || '')
+    output.set('plus_code', fields.plus_code || '')
+    output.set('success', success)
+}
+
+// clean data; on API failure pass through raw form fields so intake always proceeds
 const apiResponse = await clean(email, phone, address, city, zipCode)
 
-// default to passing through input data
 if (apiResponse) {
-    output.set('phone', apiResponse.phone || phone || '')
-    output.set('phone_is_invalid', apiResponse.phone_is_invalid || false)
-    output.set('phone_is_intl', apiResponse.phone_is_intl || false)
-    output.set('email', apiResponse.email || email || '')
-    output.set('email_error', apiResponse.email_error || '')
-    output.set(
-        'cleaned_address',
-        apiResponse.cleaned_address || [address, city, zipCode].join(' ') || ''
+    setOutputs(
+        {
+            phone: apiResponse.phone || phone,
+            phone_is_invalid: apiResponse.phone_is_invalid,
+            phone_is_intl: apiResponse.phone_is_intl,
+            email: apiResponse.email || email,
+            email_error: apiResponse.email_error,
+            cleaned_address: apiResponse.cleaned_address || passThroughAddress,
+            cleaned_address_accuracy: apiResponse.cleaned_address_accuracy,
+            bin: apiResponse.bin,
+            plus_code: apiResponse.plus_code,
+        },
+        true
     )
-    output.set('cleaned_address_accuracy', apiResponse.cleaned_address_accuracy || '')
-    output.set('bin', apiResponse.bin || '')
-    output.set('plus_code', apiResponse.plus_code || '')
-    output.set('success', true)
 } else {
-    output.set('success', false)
+    setOutputs(
+        {
+            phone,
+            email,
+            cleaned_address: passThroughAddress,
+        },
+        false
+    )
 }
 

--- a/automation-scripts/v2/transform-form-submission/clean-record.js
+++ b/automation-scripts/v2/transform-form-submission/clean-record.js
@@ -26,16 +26,60 @@ const clean = async (email, phone, address, city_state, zipcode) => {
 
 const passThroughAddress = [address, city, zipCode].join(' ') || ''
 
+const NO_EMAIL_ERROR = 'No email address provided'
+const NO_ADDRESS_ACCURACY = 'No result'
+
+const passThroughFields = {
+    phone: phone || '',
+    phone_is_invalid: !(phone || '').trim(),
+    phone_is_intl: false,
+    email: email || '',
+    email_error: (email || '').trim() ? '' : NO_EMAIL_ERROR,
+    cleaned_address: passThroughAddress,
+    cleaned_address_accuracy: passThroughAddress.trim() ? '' : NO_ADDRESS_ACCURACY,
+    bin: '',
+    plus_code: '',
+}
+
+const stringOrPassThrough = (value, fallback) =>
+    value === null || value === undefined || value === '' ? fallback : value
+
 const setOutputs = (fields, success) => {
-    output.set('phone', fields.phone || '')
-    output.set('phone_is_invalid', fields.phone_is_invalid || false)
-    output.set('phone_is_intl', fields.phone_is_intl || false)
-    output.set('email', fields.email || '')
-    output.set('email_error', fields.email_error || '')
-    output.set('cleaned_address', fields.cleaned_address || '')
-    output.set('cleaned_address_accuracy', fields.cleaned_address_accuracy || '')
-    output.set('bin', fields.bin || '')
-    output.set('plus_code', fields.plus_code || '')
+    const resolvedPhone = stringOrPassThrough(fields.phone, passThroughFields.phone)
+    let phoneIsInvalid = fields.phone_is_invalid ?? passThroughFields.phone_is_invalid
+    if (!resolvedPhone.trim()) {
+        phoneIsInvalid = true
+    }
+
+    output.set('phone', resolvedPhone)
+    output.set('phone_is_invalid', phoneIsInvalid)
+    output.set('phone_is_intl', fields.phone_is_intl ?? passThroughFields.phone_is_intl)
+
+    const resolvedEmail = stringOrPassThrough(fields.email, passThroughFields.email)
+    let emailError = stringOrPassThrough(fields.email_error, passThroughFields.email_error)
+    if (!resolvedEmail.trim()) {
+        emailError = NO_EMAIL_ERROR
+    }
+
+    output.set('email', resolvedEmail)
+    output.set('email_error', emailError)
+
+    const resolvedCleanedAddress = stringOrPassThrough(
+        fields.cleaned_address,
+        passThroughFields.cleaned_address
+    )
+    let cleanedAddressAccuracy = stringOrPassThrough(
+        fields.cleaned_address_accuracy,
+        passThroughFields.cleaned_address_accuracy
+    )
+    if (!resolvedCleanedAddress.trim()) {
+        cleanedAddressAccuracy = NO_ADDRESS_ACCURACY
+    }
+
+    output.set('cleaned_address', resolvedCleanedAddress)
+    output.set('cleaned_address_accuracy', cleanedAddressAccuracy)
+    output.set('bin', stringOrPassThrough(fields.bin, passThroughFields.bin))
+    output.set('plus_code', stringOrPassThrough(fields.plus_code, passThroughFields.plus_code))
     output.set('success', success)
 }
 
@@ -45,12 +89,12 @@ const apiResponse = await clean(email, phone, address, city, zipCode)
 if (apiResponse) {
     setOutputs(
         {
-            phone: apiResponse.phone || phone,
+            phone: apiResponse.phone,
             phone_is_invalid: apiResponse.phone_is_invalid,
             phone_is_intl: apiResponse.phone_is_intl,
-            email: apiResponse.email || email,
+            email: apiResponse.email,
             email_error: apiResponse.email_error,
-            cleaned_address: apiResponse.cleaned_address || passThroughAddress,
+            cleaned_address: apiResponse.cleaned_address,
             cleaned_address_accuracy: apiResponse.cleaned_address_accuracy,
             bin: apiResponse.bin,
             plus_code: apiResponse.plus_code,
@@ -58,13 +102,6 @@ if (apiResponse) {
         true
     )
 } else {
-    setOutputs(
-        {
-            phone,
-            email,
-            cleaned_address: passThroughAddress,
-        },
-        false
-    )
+    setOutputs(passThroughFields, false)
 }
 

--- a/automation-scripts/v2/transform-form-submission/create-requests.js
+++ b/automation-scripts/v2/transform-form-submission/create-requests.js
@@ -79,7 +79,7 @@ if (meshRequested) {
     await meshRequestTable.createRecordAsync({
       'Internet Access': internetAccess.map((name) => ({ name })),
       Address: cleanedAddress,
-      'Address Accuracy': { name: cleanedAddressAccuracy },
+      'Address Accuracy': { name: cleanedAddressAccuracy || 'No result' },
       'Building Identification Number': Number(bin),
       ...lastRequestedFields,
     })
@@ -87,3 +87,4 @@ if (meshRequested) {
 } else {
   output.set('meshRequestId', null)
 }
+ 

--- a/automation-scripts/v2/transform-form-submission/create-requests.js
+++ b/automation-scripts/v2/transform-form-submission/create-requests.js
@@ -36,21 +36,32 @@ output.set(
   ].flat())
 )
 
+let meshRequested = false
+for (let i = 0; i < ssReqs.length; i++) {
+  if (ssReqs[i] === 'Internet de bajo costo en casa / Low-Cost Internet at home / 網絡連結協助') {
+    meshRequested = true
+    ssReqs.splice(i, 1)
+    break
+  }
+}
+
 const ssRequestTable = base.getTable('Social Service Requests')
 
 output.set(
   'ssRequestIds',
   await ssRequestTable.createRecordsAsync(
-    ssReqs.map((reqType) => {
-      const fields = { Type: { name: reqType } }
-      if (reqType === 'Internet de bajo costo en casa / Low-Cost Internet at home / 網絡連結協助') {
-        fields['Internet Access'] = internetAccess.map((name) => ({ name }))
-        fields['Roof Accessible?'] = roofAccessible
-        fields['Address'] = cleanedAddress
-        fields['Address Accuracy'] = { name: cleanedAddressAccuracy }
-        fields['Building Identification Number'] = Number(bin)
-      }
-      return { fields }
-    })
+    ssReqs.map((reqType) => ({ fields: { Type: { name: reqType } } }))
   )
+)
+
+const meshRequestTable = base.getTable('Mesh Requests')
+
+output.set(
+  'meshRequestId',
+  await meshRequestTable.createRecordAsync({
+    'Internet Access': internetAccess.map((name) => ({ name })),
+    Address: cleanedAddress,
+    'Address Accuracy': { name: cleanedAddressAccuracy },
+    'Building Identification Number': Number(bin),
+  })
 )

--- a/automation-scripts/v2/transform-form-submission/create-requests.js
+++ b/automation-scripts/v2/transform-form-submission/create-requests.js
@@ -5,7 +5,6 @@ const {
   kitchenReqs,
   ssReqs,
   internetAccess,
-  roofAccessible,
   cleanedAddress,
   cleanedAddressAccuracy,
   bin,
@@ -74,17 +73,20 @@ output.set(
 const meshRequestTable = base.getTable('Mesh Requests')
 
 if (meshRequested) {
+  const binNumber = bin != null && bin !== '' ? Number(bin) : null
+  const meshFields = {
+    'Internet Access': internetAccess.map((name) => ({ name })),
+    Address: cleanedAddress,
+    'Address Accuracy': { name: cleanedAddressAccuracy || 'No result' },
+    ...lastRequestedFields,
+  }
+  if (binNumber != null && Number.isFinite(binNumber)) {
+    meshFields['Building Identification Number'] = binNumber
+  }
   output.set(
     'meshRequestId',
-    await meshRequestTable.createRecordAsync({
-      'Internet Access': internetAccess.map((name) => ({ name })),
-      Address: cleanedAddress,
-      'Address Accuracy': { name: cleanedAddressAccuracy || 'No result' },
-      'Building Identification Number': Number(bin),
-      ...lastRequestedFields,
-    })
+    await meshRequestTable.createRecordAsync(meshFields)
   )
 } else {
   output.set('meshRequestId', null)
 }
- 

--- a/automation-scripts/v2/transform-form-submission/create-requests.js
+++ b/automation-scripts/v2/transform-form-submission/create-requests.js
@@ -21,6 +21,7 @@ const lastRequested = submissionDateOnly(formSubmittedAt)
 const lastRequestedFields = lastRequested ? { 'Last Requested': lastRequested } : {}
 
 const requestTable = base.getTable('Requests')
+const furnRequestTable = base.getTable('Furniture Requests')
 
 const nonFurnItemReqs = [
   egReqs.filter((egType) =>
@@ -36,18 +37,28 @@ const furnItemReqs = [
 
 output.set(
   'requestIds',
-  await requestTable.createRecordsAsync([
-    nonFurnItemReqs.map((reqType) => ({
-      fields: { Type: { name: reqType }, ...lastRequestedFields },
-    })),
-    furnItemReqs.map((reqType) => ({
-      fields: {
-        Type: { name: reqType },
-        Geocode: plusCode || '',
-        ...lastRequestedFields,
-      },
-    })),
-  ].flat())
+  nonFurnItemReqs.length
+    ? await requestTable.createRecordsAsync(
+        nonFurnItemReqs.map((reqType) => ({
+          fields: { Type: { name: reqType }, ...lastRequestedFields },
+        }))
+      )
+    : []
+)
+
+output.set(
+  'furnRequestIds',
+  furnItemReqs.length
+    ? await furnRequestTable.createRecordsAsync(
+        furnItemReqs.map((reqType) => ({
+          fields: {
+            Type: { name: reqType },
+            Geocode: plusCode || '',
+            ...lastRequestedFields,
+          },
+        }))
+      )
+    : []
 )
 
 let meshRequested = false
@@ -63,11 +74,13 @@ const ssRequestTable = base.getTable('Social Service Requests')
 
 output.set(
   'ssRequestIds',
-  await ssRequestTable.createRecordsAsync(
-    ssReqs.map((reqType) => ({
-      fields: { Type: { name: reqType }, ...lastRequestedFields },
-    }))
-  )
+  ssReqs.length
+    ? await ssRequestTable.createRecordsAsync(
+        ssReqs.map((reqType) => ({
+          fields: { Type: { name: reqType }, ...lastRequestedFields },
+        }))
+      )
+    : []
 )
 
 const meshRequestTable = base.getTable('Mesh Requests')

--- a/automation-scripts/v2/transform-form-submission/create-requests.js
+++ b/automation-scripts/v2/transform-form-submission/create-requests.js
@@ -10,7 +10,16 @@ const {
   cleanedAddressAccuracy,
   bin,
   plusCode,
+  formSubmittedAt,
 } = input.config()
+
+function submissionDateOnly(value) {
+  if (value == null || value === '') return null
+  return new Date(value).toISOString().slice(0, 10)
+}
+
+const lastRequested = submissionDateOnly(formSubmittedAt)
+const lastRequestedFields = lastRequested ? { 'Last Requested': lastRequested } : {}
 
 const requestTable = base.getTable('Requests')
 
@@ -29,9 +38,15 @@ const furnItemReqs = [
 output.set(
   'requestIds',
   await requestTable.createRecordsAsync([
-    nonFurnItemReqs.map((reqType) => ({ fields: { Type: { name: reqType } } })),
+    nonFurnItemReqs.map((reqType) => ({
+      fields: { Type: { name: reqType }, ...lastRequestedFields },
+    })),
     furnItemReqs.map((reqType) => ({
-      fields: { Type: { name: reqType }, Geocode: plusCode || '' },
+      fields: {
+        Type: { name: reqType },
+        Geocode: plusCode || '',
+        ...lastRequestedFields,
+      },
     })),
   ].flat())
 )
@@ -50,18 +65,25 @@ const ssRequestTable = base.getTable('Social Service Requests')
 output.set(
   'ssRequestIds',
   await ssRequestTable.createRecordsAsync(
-    ssReqs.map((reqType) => ({ fields: { Type: { name: reqType } } }))
+    ssReqs.map((reqType) => ({
+      fields: { Type: { name: reqType }, ...lastRequestedFields },
+    }))
   )
 )
 
 const meshRequestTable = base.getTable('Mesh Requests')
 
-output.set(
-  'meshRequestId',
-  await meshRequestTable.createRecordAsync({
-    'Internet Access': internetAccess.map((name) => ({ name })),
-    Address: cleanedAddress,
-    'Address Accuracy': { name: cleanedAddressAccuracy },
-    'Building Identification Number': Number(bin),
-  })
-)
+if (meshRequested) {
+  output.set(
+    'meshRequestId',
+    await meshRequestTable.createRecordAsync({
+      'Internet Access': internetAccess.map((name) => ({ name })),
+      Address: cleanedAddress,
+      'Address Accuracy': { name: cleanedAddressAccuracy },
+      'Building Identification Number': Number(bin),
+      ...lastRequestedFields,
+    })
+  )
+} else {
+  output.set('meshRequestId', null)
+}

--- a/core/bam_core/lib/airtable_v2.py
+++ b/core/bam_core/lib/airtable_v2.py
@@ -150,6 +150,22 @@ class Request(BaseRequest):
     table_name = 'Requests'
 
     type = F.SelectField('Type')
+
+    if TYPE_CHECKING:
+        def __init__(
+            self, *,
+            household: Household,
+            type: str,
+            status: str = "Open",
+            legacy_date_submitted: date | None,
+            last_requested: date | None,
+        ): ...
+
+
+class FurnitureRequest(BaseRequest):
+    table_name = 'Furniture Requests'
+
+    type = F.SelectField('Type')
     geocode = F.TextField('Geocode')
 
     if TYPE_CHECKING:
@@ -162,6 +178,7 @@ class Request(BaseRequest):
             last_requested: date | None,
             geocode: str | None = None
         ): ...
+
 
 class SocialServiceRequest(BaseRequest):
     table_name = 'Social Service Requests'

--- a/core/bam_core/lib/airtable_v2.py
+++ b/core/bam_core/lib/airtable_v2.py
@@ -185,9 +185,6 @@ class MeshRequest(BaseRequest):
     table_name = 'Mesh Requests'
 
     internet_access = F.MultipleSelectField('Internet Access')
-    roof_is_accessible = F.CheckboxField('Roof Accessible?')
-    has_los = F.CheckboxField('Has LOS?')
-    
     address = F.TextField('Address')
     address_accuracy = F.SelectField('Address Accuracy')
     building_identification_number = F.NumberField('Building Identification Number')
@@ -203,8 +200,6 @@ class MeshRequest(BaseRequest):
             legacy_date_submitted: date | None,
             last_requested: date | None,
             internet_access: List[str] | None = None,
-            roof_is_accessible: bool = False,
-            has_los: bool = False,
             address: str | None = None,
             address_accuracy: str | None = None,
             building_identification_number: int | None = None,

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -501,12 +501,12 @@ def transform_mesh_requests(
             mesh_address = transform_address(bin_records)
             internet_access = transform_internet_access("Internet Access", "Internet Access", bin_records)
             
-            if mesh_status_rank in [7, 8, 9, 10, 12]:
+            if mesh_status_rank in [7, 8, 9, 12]:
                 has_los = True
             else:
                 has_los = any([(r.get("MESH - Has LOS") or False) for r in bin_records])
 
-            if mesh_status_rank in [6, 7, 8, 9, 10, 12]:
+            if mesh_status_rank in [6, 7, 8, 9, 12]:
                 roof_is_accessible = True
             else:
                 field_name = "MESH - To confirm during outreach (before install)"

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -19,6 +19,7 @@ from bam_core.lib.airtable_v2 import (
     Household,
     MeshRequest,
     Request,
+    FurnitureRequest,
     SocialServiceRequest,
 )
 from bam_core.utils.phone import (
@@ -811,7 +812,7 @@ def transform_households(households: dict[str, list[dict]]) -> list[dict]:
 #######################################
 
 @retry(attempts=5, wait=1, backoff=2)
-def create_requests_records(record: dict, household: Household):
+def create_eg_requests_records(record: dict, household: Household):
     """
     Create Requests rows from the transformed legacy assistance request record.
     :param record: The transformed household record
@@ -825,42 +826,62 @@ def create_requests_records(record: dict, household: Household):
         "Cama / Bed / 床",
     ]
 
-    TYPE_MAP = {
-        "Bastidor individual / Twin Bed Frame 單人床架" : "Bastidor individual / Twin Bed Frame / 單人床架",
-    }
-
     # combine the list of requests (no address information)
-    all_reqs1 = pd.concat([
+    all_reqs = pd.concat([
         record.get("Request Types", pd.DataFrame()),
         record.get("Kitchen Items", pd.DataFrame()),
     ], ignore_index=True)
-    request_records1 = []
-    if all_reqs1.shape[0] > 0:
-        request_records1 = [
+    request_records = []
+    if all_reqs.shape[0] > 0:
+        request_records = [
             Request(
                 household=household,
-                type=TYPE_MAP.get(req_type, req_type),
+                type=req_type,
                 status="Open",
                 legacy_date_submitted=format_date(oldest_date),
                 last_requested=format_date(latest_date),
             )
             for req_type, oldest_date, latest_date in zip(
-                all_reqs1["item"],
-                all_reqs1["Legacy First "+DATE_SUBMITTED_FIELD],
-                all_reqs1["Legacy Last "+DATE_SUBMITTED_FIELD],
+                all_reqs["item"],
+                all_reqs["Legacy First "+DATE_SUBMITTED_FIELD],
+                all_reqs["Legacy Last "+DATE_SUBMITTED_FIELD],
             )
             if req_type not in TYPES_TO_EXCLUDE
         ]
 
+    if request_records:
+        Request.batch_save(request_records)
+    return request_records
+
+
+@retry(attempts=5, wait=1, backoff=2)
+def create_furniture_requests_records(record: dict, household: Household):
+    """
+    Create Furniture Requests rows from the transformed legacy assistance request record.
+    :param record: The transformed household record
+    :param household: The saved Household instance
+    :return: List of Furniture Request instances (empty if none to create)
+    """
+    
+    TYPES_TO_EXCLUDE = [
+        "Muebles / Furniture / 家具",
+        "Cosas de Cocina / Kitchen Supplies / 廚房用品",
+        "Cama / Bed / 床",
+    ]
+
+    TYPE_MAP = {
+        "Bastidor individual / Twin Bed Frame 單人床架" : "Bastidor individual / Twin Bed Frame / 單人床架",
+    }
+
     # combine the list of requests (with geocode, and no other address information)
-    all_reqs2 = pd.concat([
+    all_reqs = pd.concat([
         record.get("Furniture Items", pd.DataFrame()),
         record.get("Bed Details", pd.DataFrame()),
     ], ignore_index=True)
-    request_records2 = []
-    if all_reqs2.shape[0] > 0:
-        request_records2 = [
-            Request(
+    request_records = []
+    if all_reqs.shape[0] > 0:
+        request_records = [
+            FurnitureRequest(
                 household=household,
                 type=TYPE_MAP.get(req_type, req_type),
                 status="Open",
@@ -869,16 +890,15 @@ def create_requests_records(record: dict, household: Household):
                 geocode=record.get("Geocode"),
             )
             for req_type, oldest_date, latest_date in zip(
-                all_reqs2["item"],
-                all_reqs2["Legacy First "+DATE_SUBMITTED_FIELD],
-                all_reqs2["Legacy Last "+DATE_SUBMITTED_FIELD],
+                all_reqs["item"],
+                all_reqs["Legacy First "+DATE_SUBMITTED_FIELD],
+                all_reqs["Legacy Last "+DATE_SUBMITTED_FIELD],
             )
             if req_type not in TYPES_TO_EXCLUDE
         ]
 
-    request_records = request_records1 + request_records2
     if request_records:
-        Request.batch_save(request_records)
+        FurnitureRequest.batch_save(request_records)
     return request_records
 
 
@@ -989,18 +1009,10 @@ def load_household(record: dict):
     :return: None
     """
     household = create_household_record(record)
-    create_requests_records(record, household)
+    create_eg_requests_records(record, household)
+    create_furniture_requests_records(record, household)
     create_ss_requests_records(record, household)
     create_mesh_requests_records(record, household)
-
-
-#######################################
-#   Helper Functions for Testing     #
-#######################################
-
-def _has_mesh_requests(record: dict):
-    mesh_reqs = record.get("MESH Requests", [])
-    return len(mesh_reqs) > 0
 
 
 #######################################

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -386,8 +386,10 @@ def get_best_mesh_status(mesh_records: list[dict]) -> tuple[str | None, int | No
         
         # In-progress (open):
         "Texted about Mesh": 1,
+        "Contacted about Mesh": 1,
 
         "Step 1 - Interested in Mesh": 2,
+        "Interested in Mesh": 2,
 
         "Needs Panorama": 3,
         "Step 2.5 (optional) - Needs Panorama": 3,
@@ -405,29 +407,33 @@ def get_best_mesh_status(mesh_records: list[dict]) -> tuple[str | None, int | No
         "LOS confirmed - Update this": 7,
         "LOS Tool Confirmed": 7,
         "Step 3 - LOS Confirmed": 7,
+        "Step 2 - LOS Confirmed": 7,
+        "LOS Confirmed": 7,
 
         "Step 3 - Scheduling IN-PROGRESS": 8,
+        "Scheduling IN-PROGRESS": 8,
         "Install in-progress": 8,
         "Install in-progress 2022": 8,
         "Step 5 - Install in-progress": 8,
 
         "Install Scheduled": 9,
 
-        # Delivered:
-        "YAY! MESH INSTALLED!": 10,
-        "Mesh installed": 10,
-        "Step 6 - Mesh installed": 10,
+        # Timed-out / ignore:
+        "NYCHA - Currently Does Not Qualify": 10,
+        "Cannot Install - Other Reason": 10,
+        ">> MESH Cannot Install": 10,
+        "Cannot Install - Does not have LOS": 10,
+        "Does not have LOS": 10,
+        "No LOS confirmed": 10,
+        "Cannot Install - No Roof Access": 10,
+        "No Roof Access": 10,
+        "Not Interested": 10,
+        "Cannot Install": 10,
 
-        # Closed / ignore:
-        "NYCHA - Currently Does Not Qualify": 11,
-        "Cannot Install - Other Reason": 11,
-        ">> MESH Cannot Install": 11,
-        "Cannot Install - Does not have LOS": 11,
-        "Does not have LOS": 11,
-        "No LOS confirmed": 11,
-        "Cannot Install - No Roof Access": 11,
-        "No Roof Access": 11,
-        "Not Interested": 11,
+        # Delivered:
+        "YAY! MESH INSTALLED!": 11,
+        "Mesh installed": 11,
+        "Step 6 - Mesh installed": 11,
         
         # Needs repair (open):
         "INSTALL PENDING ELDERT REPAIR": 12,
@@ -439,6 +445,10 @@ def get_best_mesh_status(mesh_records: list[dict]) -> tuple[str | None, int | No
         "Node Building": "Open",
         "Step 2.6 (optional) Node Building": "Open",
 
+        "Texted about Mesh": "Contacted about Mesh",
+
+        "Step 1 - Interested in Mesh":  "Interested in Mesh",
+
         "Needs Panorama": "Needs Panorama",
         "Step 2.5 (optional) - Needs Panorama": "Needs Panorama",
 
@@ -446,24 +456,31 @@ def get_best_mesh_status(mesh_records: list[dict]) -> tuple[str | None, int | No
 
         "Step 4 - Roof Access Confirmed": "Roof Access Confirmed",
 
-        "Step 2- LOS Confirmed": "Step 2 - LOS Confirmed",
-        "Step 2 - LOS Tool Confirmed": "Step 2 - LOS Confirmed",
-        "LOS confirmed": "Step 2 - LOS Confirmed",
-        "LOS confirmed - Update this": "Step 2 - LOS Confirmed",
-        "LOS Tool Confirmed": "Step 2 - LOS Confirmed",
-        "Step 3 - LOS Confirmed": "Step 2 - LOS Confirmed",
-        
-        "Install in-progress": "Step 3 - Scheduling IN-PROGRESS",
-        "Install in-progress 2022": "Step 3 - Scheduling IN-PROGRESS",
-        "Step 5 - Install in-progress": "Step 3 - Scheduling IN-PROGRESS",
-        
+        "Step 2- LOS Confirmed": "LOS Confirmed",
+        "Step 2 - LOS Tool Confirmed": "LOS Confirmed",
+        "LOS confirmed": "LOS Confirmed",
+        "LOS confirmed - Update this": "LOS Confirmed",
+        "LOS Tool Confirmed": "LOS Confirmed",
+        "Step 3 - LOS Confirmed": "LOS Confirmed",
+        "Step 2 - LOS Confirmed": "LOS Confirmed",
+
+        "Install in-progress": "Scheduling IN-PROGRESS",
+        "Install in-progress 2022": "Scheduling IN-PROGRESS",
+        "Step 5 - Install in-progress": "Scheduling IN-PROGRESS",
+        "Step 3 - Scheduling IN-PROGRESS": "Scheduling IN-PROGRESS",
+
         "Mesh installed": "YAY! MESH INSTALLED!",
         "Step 6 - Mesh installed": "YAY! MESH INSTALLED!",
-        
-        "Does not have LOS": "Cannot Install - Does not have LOS",
-        "No LOS confirmed": "Cannot Install - Does not have LOS",
-        "No Roof Access": "Cannot Install - No Roof Access",
-        ">> MESH Cannot Install": "Cannot Install - Other Reason",
+
+        "NYCHA - Currently Does Not Qualify": "Cannot Install",
+        "Cannot Install - Other Reason": "Cannot Install",
+        ">> MESH Cannot Install": "Cannot Install",
+        "Cannot Install - Does not have LOS": "Cannot Install",
+        "Does not have LOS": "Cannot Install",
+        "No LOS confirmed": "Cannot Install",
+        "Cannot Install - No Roof Access": "Cannot Install",
+        "No Roof Access": "Cannot Install",
+        "Not Interested": "Cannot Install",
     }
     
     # pick the best non-closed MESH status:

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -500,24 +500,9 @@ def transform_mesh_requests(
             mesh_dates = transform_date_submitted(DATE_SUBMITTED_FIELD, DATE_SUBMITTED_FIELD, bin_records)
             mesh_address = transform_address(bin_records)
             internet_access = transform_internet_access("Internet Access", "Internet Access", bin_records)
-            
-            if mesh_status_rank in [7, 8, 9, 12]:
-                has_los = True
-            else:
-                has_los = any([(r.get("MESH - Has LOS") or False) for r in bin_records])
-
-            if mesh_status_rank in [6, 7, 8, 9, 12]:
-                roof_is_accessible = True
-            else:
-                field_name = "MESH - To confirm during outreach (before install)"
-                field_value = "Tengo acceso de mi techo / Roof access in my building"
-                roof_is_accessible = any([field_value in (r.get(field_name) or []) for r in bin_records])
-            
             mesh_requests.append({
                 "Status": mesh_status,
                 "Building Identification Number": convert_str_to_int(bin_val),
-                "Roof Accessible?": roof_is_accessible,
-                "Has LOS?": has_los,
                 **mesh_dates,
                 **mesh_address,
                 **internet_access,
@@ -612,21 +597,23 @@ def transform_open_requests(
 
     # exclude these items from migration
     EXCLUDE_ITEMS = [
-        "Asistencia legal de inquilinos / Tenant legal assistance / 租戶法律協助",
-        "Asistencia con servicios escolares / Assistance with in-school services / 學校服務協助",
-        "Asistencia asegurando vivienda/ Securing housing / 住房協助",
-        "Asistencia con seguro médico / Medical insurance support / 醫療保險協助",
-        "Asistencia de Negocios / Small Business Support / 小型企業協助",
-        "Asistencia con beneficios de comida / Assistance with food benefits / 食品福利協助（WIC, SNAP, P-EBT）",
-        "Asistencia con Transporte / Transportation Assistance / 交通運輸協助",
+    # NOT excluding these social service types for now.
+        # "Asistencia legal de inquilinos / Tenant legal assistance / 租戶法律協助",
+        # "Asistencia con servicios escolares / Assistance with in-school services / 學校服務協助",
+        # "Asistencia asegurando vivienda/ Securing housing / 住房協助",
+        # "Asistencia con seguro médico / Medical insurance support / 醫療保險協助",
+        # "Asistencia de Negocios / Small Business Support / 小型企業協助",
+        # "Asistencia con beneficios de comida / Assistance with food benefits / 食品福利協助（WIC, SNAP, P-EBT）",
+        # "Asistencia con Transporte / Transportation Assistance / 交通運輸協助",
+        # "Asistencia para mascotas / Pet Assistance / 寵物協助",
+    # Excluding these types from migration:
         "Asistencia legal de inmigración / Immigration legal assistance / 移民法律協助",
-        "Asistencia para mascotas / Pet Assistance / 寵物協助",
         "Comida de mascota / Pet Food / 寵物食品",
         "Alimentos / Groceries / 食品",
         "Comida caliente / Hot meals / 热食",
         "Otras / Other / 其他家具",
         "Otras / Other / 其他廚房用品",
-        LOW_COST_INTERNET_AT_HOME_TYPE, # MESH Requests are handled separately
+        LOW_COST_INTERNET_AT_HOME_TYPE, # MESH Requests handled separately
     ]
 
     all_items_df = [
@@ -945,8 +932,6 @@ def create_mesh_requests_records(record: dict, household: Household):
                 legacy_date_submitted=format_date(r.get("Legacy First "+DATE_SUBMITTED_FIELD)),
                 last_requested=format_date(r.get("Legacy Last "+DATE_SUBMITTED_FIELD)),
                 internet_access=r.get("Internet Access") or [],
-                roof_is_accessible=r.get("Roof Accessible?", False),
-                has_los=r.get("Has LOS?", False),
                 address_accuracy=r.get("Address Accuracy"),
                 address=r.get("Address"),
                 street_address=r.get("Street Address"),

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -834,7 +834,7 @@ def create_requests_records(record: dict, household: Household):
         request_records1 = [
             Request(
                 household=household,
-                type=req_type,
+                type=TYPE_MAP.get(req_type, req_type),
                 status="Open",
                 legacy_date_submitted=format_date(oldest_date),
                 last_requested=format_date(latest_date),
@@ -846,6 +846,11 @@ def create_requests_records(record: dict, household: Household):
             )
             if req_type not in TYPES_TO_EXCLUDE
         ]
+
+    TYPE_MAP = {
+        "Bastidor individual / Twin Bed Frame 單人床架" : "Bastidor individual / Twin Bed Frame / 單人床架",
+        "Asistencia asegurando vivienda/ Securing housing / 住房協助": "Asistencia asegurando vivienda / Securing housing / 住房協助",
+    }
 
     # combine the list of requests (with geocode, and no other address information)
     all_reqs2 = pd.concat([

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -377,69 +377,80 @@ def get_best_mesh_status(mesh_records: list[dict]) -> tuple[str | None, int | No
 
     # MESH status pipeline (higher --> further along).
     MESH_PIPELINE_RANK = {
-        # Empty `MESH - Status` (open):
+        # Empty (open):
         "": 0,
         "Duplicate": 0,
-        "Needs Panorama": 0,
-        "Step 2.5 (optional) - Needs Panorama": 0,
         "Node Building": 0,
         "Step 2.6 (optional) Node Building": 0,
         
         # In-progress (open):
         "Texted about Mesh": 1,
-        "Step 1 - Interested in Mesh": 2,
-        "Roof Access In Process": 3,
-        "Confirming Premission with Landlord": 4,
-        "Roof Access Confirmed": 5,
-        "Step 4 - Roof Access Confirmed": 5,
-        "Step 2- LOS Confirmed": 6,
-        "Step 2 - LOS Tool Confirmed": 6,
-        "LOS confirmed": 6,
-        "LOS confirmed - Update this": 6,
-        "LOS Tool Confirmed": 6,
-        "Step 3 - LOS Confirmed": 6,
-        "Step 3 - Scheduling IN-PROGRESS": 7,
-        "Install in-progress": 7,
-        "Install in-progress 2022": 7,
-        "Step 5 - Install in-progress": 7,
-        "Install Scheduled": 8,
 
-        # Delivered / Closed / ignore:
-        "YAY! MESH INSTALLED!": 9,
-        "Mesh installed": 9,
-        "Step 6 - Mesh installed": 9,
-        "NYCHA - Currently Does Not Qualify": 10,
-        "Cannot Install - Other Reason": 10,
-        ">> MESH Cannot Install": 10,
-        "Cannot Install - Does not have LOS": 10,
-        "Does not have LOS": 10,
-        "No LOS confirmed": 10,
-        "Cannot Install - No Roof Access": 10,
-        "No Roof Access": 10,
-        "Not Interested": 10,
+        "Step 1 - Interested in Mesh": 2,
+
+        "Needs Panorama": 3,
+        "Step 2.5 (optional) - Needs Panorama": 3,
+
+        "Roof Access In Process": 4,
+
+        "Confirming Premission with Landlord": 5,
+
+        "Roof Access Confirmed": 6,
+        "Step 4 - Roof Access Confirmed": 6,
+
+        "Step 2- LOS Confirmed": 7,
+        "Step 2 - LOS Tool Confirmed": 7,
+        "LOS confirmed": 7,
+        "LOS confirmed - Update this": 7,
+        "LOS Tool Confirmed": 7,
+        "Step 3 - LOS Confirmed": 7,
+
+        "Step 3 - Scheduling IN-PROGRESS": 8,
+        "Install in-progress": 8,
+        "Install in-progress 2022": 8,
+        "Step 5 - Install in-progress": 8,
+
+        "Install Scheduled": 9,
+
+        # Delivered:
+        "YAY! MESH INSTALLED!": 10,
+        "Mesh installed": 10,
+        "Step 6 - Mesh installed": 10,
+
+        # Closed / ignore:
+        "NYCHA - Currently Does Not Qualify": 11,
+        "Cannot Install - Other Reason": 11,
+        ">> MESH Cannot Install": 11,
+        "Cannot Install - Does not have LOS": 11,
+        "Does not have LOS": 11,
+        "No LOS confirmed": 11,
+        "Cannot Install - No Roof Access": 11,
+        "No Roof Access": 11,
+        "Not Interested": 11,
         
         # Needs repair (open):
-        "INSTALL PENDING ELDERT REPAIR": 11,
+        "INSTALL PENDING ELDERT REPAIR": 12,
     }
-    OPEN_RANKS = list(range(9)) + [11]
+    OPEN_RANKS = list(range(10)) + [12]
     MESH_STATUS_OLD_TO_NEW = {
         "": "Open",
         "Duplicate": "Open",
-        "Needs Panorama": "Open",
-        "Step 2.5 (optional) - Needs Panorama": "Open",
         "Node Building": "Open",
         "Step 2.6 (optional) Node Building": "Open",
 
+        "Needs Panorama": "Needs Panorama",
+        "Step 2.5 (optional) - Needs Panorama": "Needs Panorama",
+
         "Confirming Premission with Landlord": "Confirming Permission with Landlord",
-        
+
+        "Step 4 - Roof Access Confirmed": "Roof Access Confirmed",
+
         "Step 2- LOS Confirmed": "Step 2 - LOS Confirmed",
         "Step 2 - LOS Tool Confirmed": "Step 2 - LOS Confirmed",
         "LOS confirmed": "Step 2 - LOS Confirmed",
         "LOS confirmed - Update this": "Step 2 - LOS Confirmed",
         "LOS Tool Confirmed": "Step 2 - LOS Confirmed",
         "Step 3 - LOS Confirmed": "Step 2 - LOS Confirmed",
-        
-        "Step 4 - Roof Access Confirmed": "Roof Access Confirmed",
         
         "Install in-progress": "Step 3 - Scheduling IN-PROGRESS",
         "Install in-progress 2022": "Step 3 - Scheduling IN-PROGRESS",
@@ -490,12 +501,12 @@ def transform_mesh_requests(
             mesh_address = transform_address(bin_records)
             internet_access = transform_internet_access("Internet Access", "Internet Access", bin_records)
             
-            if mesh_status_rank in [6, 7, 8, 11]:
+            if mesh_status_rank in [7, 8, 9, 10, 12]:
                 has_los = True
             else:
                 has_los = any([(r.get("MESH - Has LOS") or False) for r in bin_records])
 
-            if mesh_status_rank in [5, 6, 7, 8, 11]:
+            if mesh_status_rank in [6, 7, 8, 9, 10, 12]:
                 roof_is_accessible = True
             else:
                 field_name = "MESH - To confirm during outreach (before install)"

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -251,26 +251,27 @@ def transform_languages(
     Also apply a mapping to the languages to map from the old names to the new names.
     """
 
+    OTHER_LANGUAGE = "Otro / Other / 其他語言"
     LANGUAGE_MAPPING = {
         "Chino Toishanese / Toishanese / 台山话": "Chino Toishanés / Toishanese / 台山话",
         "Chino Cantonese / Cantonese / 广东话": "Chino Cantonés / Cantonese / 广东话",
         "Arabic / 阿拉伯語": "Árabe / Arabic / 阿拉伯語",
         "Portuguese / 葡萄牙語": "Portugués / Portuguese / 葡萄牙語",
         "Portuguese": "Portugués / Portuguese / 葡萄牙語",
-        "Otro / Other / 别的方言": "Otro / Other / 其他語言",
         "Haitian Creole / French Creole / 法屬歸融語": "Criollo Haitiano / Haitian Creole / 法屬歸融語",
+        "Otro / Other / 别的方言": OTHER_LANGUAGE,
     }
 
     output = transform_lists(old_field_name, new_field_name, records)
     # apply language mapping and deduplicate
-    output[new_field_name] = list(
-        set(
-            [
-                LANGUAGE_MAPPING.get(item, item)
-                for item in output[new_field_name]
-            ]
-        )
-    )
+    languages = list(set([
+        LANGUAGE_MAPPING.get(item, item)
+        for item in output[new_field_name]
+    ]))
+    if OTHER_LANGUAGE in languages:
+        languages.remove(OTHER_LANGUAGE)
+        languages.append(OTHER_LANGUAGE)
+    output[new_field_name] = languages
     return output
 
 

--- a/core/scripts/migrate_requests_to_new_base.py
+++ b/core/scripts/migrate_requests_to_new_base.py
@@ -818,11 +818,16 @@ def create_requests_records(record: dict, household: Household):
     :param household: The saved Household instance
     :return: List of Request instances (empty if none to create)
     """
+    
     TYPES_TO_EXCLUDE = [
         "Muebles / Furniture / 家具",
         "Cosas de Cocina / Kitchen Supplies / 廚房用品",
         "Cama / Bed / 床",
     ]
+
+    TYPE_MAP = {
+        "Bastidor individual / Twin Bed Frame 單人床架" : "Bastidor individual / Twin Bed Frame / 單人床架",
+    }
 
     # combine the list of requests (no address information)
     all_reqs1 = pd.concat([
@@ -847,11 +852,6 @@ def create_requests_records(record: dict, household: Household):
             if req_type not in TYPES_TO_EXCLUDE
         ]
 
-    TYPE_MAP = {
-        "Bastidor individual / Twin Bed Frame 單人床架" : "Bastidor individual / Twin Bed Frame / 單人床架",
-        "Asistencia asegurando vivienda/ Securing housing / 住房協助": "Asistencia asegurando vivienda / Securing housing / 住房協助",
-    }
-
     # combine the list of requests (with geocode, and no other address information)
     all_reqs2 = pd.concat([
         record.get("Furniture Items", pd.DataFrame()),
@@ -862,7 +862,7 @@ def create_requests_records(record: dict, household: Household):
         request_records2 = [
             Request(
                 household=household,
-                type=req_type,
+                type=TYPE_MAP.get(req_type, req_type),
                 status="Open",
                 legacy_date_submitted=format_date(oldest_date),
                 last_requested=format_date(latest_date),
@@ -892,7 +892,8 @@ def create_ss_requests_records(record: dict, household: Household):
     """
     
     TYPE_MAP = {
-        "Asistencia para niños discapacitados / Assistance for disabled children / 殘疾兒童協助": "Asistencia para niños con discapacidad / Assistance for disabled children / 殘疾兒童協助"
+        "Asistencia para niños discapacitados / Assistance for disabled children / 殘疾兒童協助": "Asistencia para niños con discapacidad / Assistance for disabled children / 殘疾兒童協助",
+        "Asistencia asegurando vivienda/ Securing housing / 住房協助": "Asistencia asegurando vivienda / Securing housing / 住房協助",
     }
 
     ss_reqs = record.get("Social Service Requests", pd.DataFrame())


### PR DESCRIPTION

---

## Intake — `create-requests.js`

**Automation**
[On Create] Write form submission to household, request tables

**Script changes**
- Sets **`Last Requested`** from form submission date (`formSubmittedAt` input)
- Routes low-cost internet to **`Mesh Requests`** (not SS)
- **`Building Identification Number`** set when clean-record returns a valid BIN; omitted otherwise (Mesh row still created)

**Live base**
- Input **`formSubmittedAt`** wired to the Run script step
- **`Mesh Requests`** row created via separate `meshRequestId` output (household Create step links it)
- Internet no longer written as an SS **`Type`** row

---

## Merge — `merge-households.js`

**Automation**
[On Create] Merge households
[On Update] Merge households on phone # update

**Script changes**
- Contact fields (Name, Email, flags) from intake / `newHouseholdId`
- On Update automation includes Mesh find/consolidate steps

---

## Consolidate — `consolidate-requests.js`

**Automation**
[On Create] Merge households
[On Update] Merge households on phone # update

**Script changes**
- Survivor = earliest **`Request Opened At`**; **`Legacy Date Submitted`** = min; **`Last Requested`** max
- **Furniture Requests:** **`Geocode`** newest
- **SS:** same Type → **`Partner Org`** multiselect union
- **Mesh:** same BIN → **`Status`** by pipeline rank; address bundle by **`Address Accuracy`** rank

**Live base**
- **Merge** Mesh finds all linked rows on merged household, so same-BIN consolidate can merge mixed pipeline stages via **`maxMeshStatus`**

---

## Count — `count-closed-requests.js`

**Automation**
[At 23:45 EST] Count and delete older closed records

**Script changes**
- Count column = English middle segment of **`Type`**: `Type.split(' / ')[1]`
- Mesh column hard-coded: **`Low-Cost Home Internet`**
- Counts **Delivered** (Requests/SS) and **`YAY! MESH INSTALLED!`** (Mesh) only; deletes all rows in input lists
- Mesh: once per phone per close date

**Live base**
- **`Fulfilled Request Count`** type columns renamed to match Type middle segments (sentence-case English) except MESH, e.g. **`Hot meals`**, **`Securing housing`**, **`Twin Bed Frame`**
- Script receives `requestIds`, `ssRequestIds`, `meshRequestIds` from Find steps
- **Find closed requests** (Requests): **Delivered** OR **Timeout**, **`Processing Date`** ≤ today
- **Find closed social service requests** (SS): **Delivered** OR **Timeout**, **`Processing Date`** ≤ today
- **Find closed MESH requests** (Mesh): **`Processing Date`** ≤ today (which is only set for installed or can not install)

---

## Migration — `migrate_requests_to_new_base.py`

**Script changes**
- Mesh pipeline ranks realigned (Needs Panorama = 3, installed = 10, terminal = 11, repair = 12)
- **`TYPE_MAP` at write:** Twin Bed → 3-segment label; SS disabled-children label; securing-housing spacing
- Now migrating all social service types

**Live base**
- Export maps align migrated **`Type`** values with live select options used by intake and count scripts above

---

## ORM — `airtable_v2.py`

**Script changes**
- Remove **`Roof Accessible?`** / **`Has LOS?`** from `MeshRequest` (not on live Mesh table)

**Live base**
- **`Roof Accessible?`** / **`Has LOS?`** removed from **`Mesh Requests`**
- **`Roof Accessible?`** remains on **`Assistance Request Form Submissions`** (Fillout) only

---
