### PR TITLE
Address Copilot review comments on #49

### DIFF
--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -10,6 +10,16 @@ const countCols = countTable.fields;
 let allCounts = null;
 const dateRecordPromises = new Map();
 
+// Normalize an Airtable date/dateTime cell value (string or Date) to a
+// stable date-only `YYYY-MM-DD` key. This keeps grouping and the count
+// table's Date lookup consistent, avoiding both time-of-day bucket splits
+// and comparisons that never match across value types.
+function toDateKey(value) {
+  if (value == null) return null;
+  const iso = typeof value === 'string' ? value : value.toISOString();
+  return iso.slice(0, 10);
+}
+
 async function getAllCounts() {
   if (allCounts === null) {
     allCounts = (await countTable.selectRecordsAsync({ fields: countCols })).records;
@@ -24,7 +34,7 @@ async function findOrCreateCountRecord(date) {
     dateRecordPromises.set(date, (async () => {
       const counts = await getAllCounts();
       for (const count of counts) {
-        if (count.getCellValue('Date') === date) return count;
+        if (toDateKey(count.getCellValue('Date')) === date) return count;
       }
 
       const recId = await countTable.createRecordAsync({ 'Date': date });
@@ -49,7 +59,7 @@ async function processRequests(table, reqIds, columnOverwrites) {
     'Type',
   ] })).records;
   for (const req of reqs) {
-    const date = req.getCellValue('Status Last Updated At');
+    const date = toDateKey(req.getCellValue('Status Last Updated At'));
     if (date == null) continue;
 
     groups[date] ??= [];
@@ -99,7 +109,7 @@ async function processMesh(table, reqIds) {
     'Phone Number (from Household)',
   ] })).records;
   for (const req of reqs) {
-    const date = req.getCellValue('Status Last Updated At');
+    const date = toDateKey(req.getCellValue('Status Last Updated At'));
     if (date == null) continue;
 
     groups[date] ??= [];

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -28,9 +28,14 @@ async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
         })
         .forEach((req) => {
             const rawKey = req.getCellValue(keyField)
-            const key = typeof rawKey === 'object'
+            let key = (typeof rawKey === 'object' && rawKey !== null)
                 ? rawKey.id
                 : rawKey
+            // A missing/blank key (e.g. a Mesh Request with no Building
+            // Identification Number) does not imply these records belong
+            // together. Give each such record a unique key so it stays in
+            // its own singleton group and is never merged with others.
+            if (key == null || key === '') key = Symbol('unkeyed')
             if (!requestGroups.has(key)) requestGroups.set(key, [])
             requestGroups.get(key).push(req)
         })
@@ -39,17 +44,24 @@ async function mergeReqs(tableName, recordIds, keyField, mergeFns) {
     for (let [, reqGroup] of requestGroups) {
         const [firstReq, ...rest] = reqGroup
 
-        const mergedFields = Object.fromEntries(Object.keys(mergeFns).map((field) => {
-            const fn = mergeFns[field]
-            const value = fn(
-                reqGroup.map((req) => req.getCellValue(field)),
-                reqGroup,
+        const mergedFields = Object.fromEntries(Object.keys(mergeFns)
+            .map((field) => {
+                const fn = mergeFns[field]
+                const value = fn(
+                    reqGroup.map((req) => req.getCellValue(field)),
+                    reqGroup,
+                )
+                return [field, value]
+            })
+            // Airtable rejects `undefined` field values; a merge fn returns
+            // undefined when it has nothing to write (e.g. minDate over all
+            // blank dates). Drop those so we leave the field untouched.
+            .filter(([, value]) => value !== undefined))
+        if (Object.keys(mergedFields).length) {
+            await requestTable.updateRecordAsync(
+                firstReq, mergedFields
             )
-            return [field, value]
-        }))
-        await requestTable.updateRecordAsync(
-            firstReq, mergedFields
-        )
+        }
         await requestTable.deleteRecordsAsync(rest)
     }
 }


### PR DESCRIPTION
Targets the head branch of #49 (`zakieh/automations`) so these fixes fold into that PR.

Addresses all five Copilot review comments:

### `count-closed-requests.js`
- **Date comparison / grouping by raw value** (comments on `findOrCreateCountRecord`, `processRequests`, `processMesh`): added a `toDateKey()` helper that normalizes any date/dateTime cell value (string or `Date`) to a stable `YYYY-MM-DD` key. It's now used both for the count-table `Date` lookup/creation and for grouping close-out records. This prevents duplicate count rows from type/instance-mismatched `===` comparisons and stops buckets from splitting by time-of-day (which was undermining the "once per phone per close date" rule for mesh).

### `consolidate-requests.js`
- **Grouping by missing `Building Identification Number`** (merge collapses all no-BIN rows): records with a blank/missing group key now get a unique key, so they stay in their own singleton group and are never merged with unrelated records.
- **`undefined` merge values passed to `updateRecordAsync`** (`minDate` returns `undefined` when all values are blank): merged fields that are `undefined` are now filtered out before the update, and the update is skipped entirely when nothing changed.