### PR TITLE
Fixes for review findings on #52

### DIFF
--- a/automation-scripts/v2/count-closed-requests/count-closed-requests.js
+++ b/automation-scripts/v2/count-closed-requests/count-closed-requests.js
@@ -8,27 +8,54 @@ const meshTable = base.getTable('Mesh Requests');
 const countTable = base.getTable('Fulfilled Request Count');
 
 const invalidCountCols = new Set();
+const uncountedRequestIds = [];
 
-async function processRequests(table, reqIds, getCountCol, deliveredStatus) {
-  if (!reqIds.length) return;
+// 'Status Last Updated At' can read back as a Date object or ISO datetime string
+// while 'Date' reads back as 'YYYY-MM-DD'; normalize both to a day-level key so
+// grouping and the find-or-create comparison actually match. Days are bucketed
+// in NY time, not the script server's timezone, so evening closes don't count
+// toward the next day.
+function toLocalDay(d) {
+  try {
+    return d.toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+  } catch (error) {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+}
 
-  // Step 1: pull all count records, define find-or-create util
-  const allCounts = (await countTable.selectRecordsAsync({
-    fields: countTable.fields,
-  })).records;
+function dateKey(value) {
+  if (value == null) return null;
+  if (value instanceof Date) return toLocalDay(value);
+  const text = String(value).trim();
+  if (/^\d{4}-\d{2}-\d{2}/.test(text)) return text.slice(0, 10);
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return toLocalDay(parsed);
+}
 
-  async function findOrCreateCountRecord(date) {
-    for (const count of allCounts) {
-      if (count.getCellValue('Date') === date) return count;
-    }
+const allCounts = (await countTable.selectRecordsAsync({
+  fields: countTable.fields,
+})).records;
 
-    const recId = await countTable.createRecordAsync({ Date: date });
-    const rec = await countTable.selectRecordAsync(recId, { fields: countTable.fields });
-    if (rec === null) throw "Airtable is broken";
-    return rec;
+async function findOrCreateCountRecord(date) {
+  for (const count of allCounts) {
+    if (dateKey(count.getCellValue('Date')) === date) return count;
   }
 
-  // Step 2: group requests by date
+  const recId = await countTable.createRecordAsync({ Date: date });
+  const rec = await countTable.selectRecordAsync(recId, { fields: countTable.fields });
+  if (rec === null) throw "Airtable is broken";
+  allCounts.push(rec);
+  return rec;
+}
+
+async function processRequests(table, reqIds, getCountCol, deliveredStatus, getCountKey) {
+  if (!reqIds?.length) return;
+
+  // Step 1: group requests by date
   const requestGroups = new Map();
 
   const reqs = (await table.selectRecordsAsync({
@@ -36,31 +63,42 @@ async function processRequests(table, reqIds, getCountCol, deliveredStatus) {
     fields: table.fields,
   })).records;
   for (const req of reqs) {
-    const date = req.getCellValue('Status Last Updated At');
+    const date = dateKey(req.getCellValue('Status Last Updated At'));
 
     if (!requestGroups.has(date)) requestGroups.set(date, []);
     requestGroups.get(date).push(req);
   }
 
-  // Step 3: process each group
+  // Step 2: process each group
   for (const [date, reqs] of requestGroups) {
     const fields = {};
     const countRec = await findOrCreateCountRecord(date);
+    const countedKeys = new Set();
 
     const reqsToDelete = [];
     for (const req of reqs) {
       // Validate counter column
       const countCol = getCountCol(req);
-      if (!countTable.fields.find((field) => (field.name === countCol))) {
-        invalidCountCols.add(countCol);
+      if (!countCol || !countTable.fields.find((field) => (field.name === countCol))) {
+        invalidCountCols.add(countCol ?? '(empty Type)');
+        uncountedRequestIds.push(req.id);
         continue;
       }
 
-      // Bump counter if delivered
-      const reqStatus = req.getCellValue('Status').name;
+      // Bump counter if delivered; when a count key is defined, count at most
+      // once per key per date (and skip records with no key at all)
+      const reqStatus = req.getCellValue('Status')?.name;
       if (reqStatus === deliveredStatus) {
-        fields[countCol] ??= countRec.getCellValue(countCol);
-        fields[countCol]++;
+        let shouldCount = true;
+        if (getCountKey) {
+          const countKey = getCountKey(req);
+          shouldCount = Boolean(countKey) && !countedKeys.has(countKey);
+          if (countKey) countedKeys.add(countKey);
+        }
+        if (shouldCount) {
+          fields[countCol] ??= countRec.getCellValue(countCol);
+          fields[countCol]++;
+        }
       }
 
       // Mark request for deletion
@@ -68,7 +106,9 @@ async function processRequests(table, reqIds, getCountCol, deliveredStatus) {
     }
 
     // Update counter
-    await countTable.updateRecordAsync(countRec, fields);
+    if (Object.keys(fields).length) {
+      await countTable.updateRecordAsync(countRec, fields);
+    }
 
     // Delete marked requests in pages of 50
     for (let idx = 0; idx < reqsToDelete.length; idx += 50) {
@@ -78,14 +118,36 @@ async function processRequests(table, reqIds, getCountCol, deliveredStatus) {
 }
 
 function getCountColFromType(req) {
-  return req.getCellValue('Type').name.split(' / ')[1];
+  const typeName = req.getCellValue('Type')?.name;
+  // Fall back to the full name when there is no ' / ' separator so the
+  // invalid-column report shows something identifiable
+  return typeName?.split(' / ')[1] ?? typeName;
+}
+
+// Mesh installs count once per household phone per close date
+const meshHasPhoneField = meshTable.fields.some(
+  (field) => field.name === 'Phone Number (from Household)'
+);
+function getHouseholdPhone(req) {
+  const phone = req.getCellValue('Phone Number (from Household)');
+  return Array.isArray(phone) ? phone[0] : phone;
 }
 
 const DELIVERED_TAG = 'Delivered'
 
-await processRequests(reqTable, requestIds, getCountColFromType, DELIVERED_TAG);
-await processRequests(furnReqTable, furnRequestIds, getCountColFromType, DELIVERED_TAG);
-await processRequests(ssReqTable, ssRequestIds, getCountColFromType, DELIVERED_TAG);
-await processRequests(meshTable, meshRequestIds, () => 'Low-Cost Home Internet', 'YAY! MESH INSTALLED!');
-
-output.set('invalidCountCols', [...invalidCountCols]);
+try {
+  await processRequests(reqTable, requestIds, getCountColFromType, DELIVERED_TAG);
+  await processRequests(furnReqTable, furnRequestIds, getCountColFromType, DELIVERED_TAG);
+  await processRequests(ssReqTable, ssRequestIds, getCountColFromType, DELIVERED_TAG);
+  await processRequests(
+    meshTable,
+    meshRequestIds,
+    () => 'Low-Cost Home Internet',
+    'YAY! MESH INSTALLED!',
+    meshHasPhoneField ? getHouseholdPhone : undefined,
+  );
+} finally {
+  // Report even if a later table's processing throws
+  output.set('invalidCountCols', [...invalidCountCols]);
+  output.set('uncountedRequestIds', uncountedRequestIds);
+}

--- a/automation-scripts/v2/merge-households/consolidate-requests.js
+++ b/automation-scripts/v2/merge-households/consolidate-requests.js
@@ -5,10 +5,9 @@ const reqTable = base.getTable('Requests');
 const furnReqTable = base.getTable('Furniture Requests');
 const ssReqTable = base.getTable('Social Service Requests');
 const meshTable = base.getTable('Mesh Requests');
-const countTable = base.getTable('Fulfilled Request Count');
 
 async function mergeRequests(table, reqIds, getKey, mergeFns) {
-    if (!reqIds.length) return
+    if (!reqIds?.length) return
 
     // Step 1: group requests by key, sorted from oldest to newest
     const requestGroups = new Map()
@@ -29,11 +28,18 @@ async function mergeRequests(table, reqIds, getKey, mergeFns) {
     for (const [, reqGroup] of requestGroups) {
         const [firstReq, ...rest] = reqGroup
 
+        // Skip null/empty merge results so a sparse duplicate can't clear
+        // populated fields on the survivor
         const mergedFields = {}
         for (const [field, fn] of Object.entries(mergeFns)) {
-            mergedFields[field] = fn(reqGroup)
+            const value = fn(reqGroup)
+            if (value == null || value === '' ||
+                (Array.isArray(value) && !value.length)) continue
+            mergedFields[field] = value
         }
-        await table.updateRecordAsync(firstReq, mergedFields)
+        if (Object.keys(mergedFields).length) {
+            await table.updateRecordAsync(firstReq, mergedFields)
+        }
         await table.deleteRecordsAsync(rest)
     }
 }
@@ -45,6 +51,8 @@ const union = (field) => (reqs) => {
     const uniqIds = [...new Set(allSelectionIds)]
     return uniqIds.map((id) => ({ id }))
 }
+const anyChecked = (field) => (reqs) =>
+    reqs.some((req) => req.getCellValue(field)) || null
 
 const MESH_STATUS_RANK = {
     'Open': 0,
@@ -62,19 +70,28 @@ const MESH_STATUS_RANK = {
     'INSTALL PENDING ELDERT REPAIR': 12,
 }
 
+const unknownMeshStatuses = new Set()
+
 const maxMeshStatus = (reqs) => {
-    const statuses = reqs.map((req) => req.getCellValue('Status'))
-    let bestStatus
+    let bestStatus = null
     let bestRank = -1
-    for (const status of statuses) {
+    for (const req of reqs) {
+        const status = req.getCellValue('Status')
+        if (!status) continue
         const rank = MESH_STATUS_RANK[status.name]
+        if (rank === undefined) {
+            unknownMeshStatuses.add(status.name)
+            continue
+        }
         if (rank > bestRank) {
             bestRank = rank
             bestStatus = status
         }
     }
 
-    return bestStatus
+    // null (not undefined) so an unrankable group leaves the survivor's
+    // Status untouched via the null-skip in mergeRequests
+    return bestStatus ? { id: bestStatus.id } : null
 }
 
 const ADDRESS_ACCURACY_RANK = {
@@ -93,7 +110,8 @@ const pickAddressBundleIndex = (reqs) => {
     let bestRank = -2
     for (let i = 0; i < reqs.length; i++) {
         const accuracy = reqs[i].getCellValue('Address Accuracy')
-        const rank = ADDRESS_ACCURACY_RANK[accuracy?.name ?? ''] ?? -2
+        // Unknown accuracy names rank like 'No result', not below 'Invalid'
+        const rank = ADDRESS_ACCURACY_RANK[accuracy?.name ?? ''] ?? 0
         if (rank >= bestRank) {
             bestRank = rank
             bestIdx = i
@@ -142,6 +160,8 @@ await mergeRequests(
         'Last Requested': getLast('Last Requested'),
         Status: maxMeshStatus,
         'Internet Access': union('Internet Access'),
+        'Roof Accessible?': anyChecked('Roof Accessible?'),
+        'Has LOS?': anyChecked('Has LOS?'),
         'Street Address': fromAddressBundle('Street Address'),
         'City, State': fromAddressBundle('City, State'),
         'Zip Code': fromAddressBundle('Zip Code'),
@@ -152,3 +172,6 @@ await mergeRequests(
         'Address Accuracy': fromAddressBundle('Address Accuracy'),
     },
 )
+
+// Surface status names missing from MESH_STATUS_RANK so map drift is visible
+output.set('unknownMeshStatuses', [...unknownMeshStatuses])

--- a/automation-scripts/v2/transform-form-submission/clean-record.js
+++ b/automation-scripts/v2/transform-form-submission/clean-record.js
@@ -2,22 +2,27 @@ const AUTOMATION_CLEAN_RECORD_ENDPOINT = 'https://api.baml.ink/clean-record'
 const { email, phone, address, city, zipCode, apiKey } = input.config()
 
 const clean = async (email, phone, address, city_state, zipcode) => {
-    const params = new URLSearchParams({
-        email,
-        phone,
-        apikey: apiKey,
-        dns_check: true.toString(),
-        address,
-        city_state,
-        zipcode,
-    })
-    const url = `${AUTOMATION_CLEAN_RECORD_ENDPOINT}?${params}`
-    const response = await fetch(url)
-    const data = await response.json()
-    if (response.status === 200) {
-        return data
-    } else {
-        console.log(`API request failed with status: ${response.status} and response:\n${JSON.stringify(data)}`)
+    try {
+        const params = new URLSearchParams({
+            email,
+            phone,
+            apikey: apiKey,
+            dns_check: true.toString(),
+            address,
+            city_state,
+            zip_code: zipcode,
+        })
+        const url = `${AUTOMATION_CLEAN_RECORD_ENDPOINT}?${params}`
+        const response = await fetch(url)
+        if (!response.ok) {
+            console.log(`API request failed with status: ${response.status} and response:\n${await response.text()}`)
+            return undefined
+        }
+        return await response.json()
+    } catch (error) {
+        // Network errors and malformed bodies must not kill the script —
+        // intake falls back to the raw form fields below
+        console.log(`API request failed: ${error}`)
         return undefined
     }
 }
@@ -43,7 +48,8 @@ output.set('email_error', cleanedEmail.trim()
     : NO_EMAIL_ERROR
 )
 
-const cleanedAddress = apiResponse?.cleaned_address || [address, city, zipCode].join(' ') || ''
+const cleanedAddress = apiResponse?.cleaned_address ||
+    [address, city, zipCode].map((part) => (part ?? '').trim()).filter(Boolean).join(' ')
 output.set('cleaned_address', cleanedAddress)
 output.set('cleaned_address_accuracy', cleanedAddress.trim()
     ? apiResponse?.cleaned_address_accuracy || ''

--- a/automation-scripts/v2/transform-form-submission/create-requests.js
+++ b/automation-scripts/v2/transform-form-submission/create-requests.js
@@ -18,6 +18,22 @@ const furnRequestTable = base.getTable('Furniture Requests')
 const ssRequestTable = base.getTable('Social Service Requests')
 const meshRequestTable = base.getTable('Mesh Requests')
 
+// 'Last Requested' is a date field; normalize the submission timestamp to the
+// local (NY) day so late-evening submissions don't land on the next UTC day
+function submissionDay(value) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  try {
+    return date.toLocaleDateString('en-CA', { timeZone: 'America/New_York' })
+  } catch (error) {
+    return date.toISOString().slice(0, 10)
+  }
+}
+
+const lastRequested = submissionDay(formSubmittedAt)
+const lastRequestedFields = lastRequested ? { 'Last Requested': lastRequested } : {}
+
 const nonFurnItemReqs = [
   egReqs.filter((egType) =>
     !['Muebles / Furniture / 家具', 'Cosas de Cocina / Kitchen Supplies / 廚房用品'].includes(egType)
@@ -34,7 +50,7 @@ output.set(
   'requestIds',
   await requestTable.createRecordsAsync(
     nonFurnItemReqs.map((reqType) => ({
-      fields: { Type: { name: reqType }, 'Last Requested': formSubmittedAt },
+      fields: { Type: { name: reqType }, ...lastRequestedFields },
     }))
   )
 )
@@ -46,7 +62,7 @@ output.set(
       fields: {
         Type: { name: reqType },
         Geocode: plusCode || '',
-        'Last Requested': formSubmittedAt,
+        ...lastRequestedFields,
       },
     }))
   )
@@ -65,23 +81,28 @@ output.set(
   'ssRequestIds',
   await ssRequestTable.createRecordsAsync(
     ssReqs.map((reqType) => ({
-      fields: { Type: { name: reqType }, 'Last Requested': formSubmittedAt },
+      fields: { Type: { name: reqType }, ...lastRequestedFields },
     }))
   )
 )
 
 if (meshRequested) {
-  const binNumber = bin ? Number(bin) : undefined
-  output.set(
-    'meshRequestId',
-    await meshRequestTable.createRecordAsync({
-      'Building Identification Number': Number.isFinite(binNumber) ? binNumber : undefined,
-      'Internet Access': internetAccess.map((name) => ({ name })),
-      Address: cleanedAddress,
-      'Address Accuracy': { name: cleanedAddressAccuracy },
-      'Last Requested': formSubmittedAt,
-    })
-  )
+  const binNumber = bin ? Number(bin) : NaN
+  const meshFields = {
+    // Single selects have no default on API-created records; without this,
+    // consolidate-requests' maxMeshStatus would see a null Status
+    Status: { name: 'Open' },
+    'Internet Access': (internetAccess || []).map((name) => ({ name })),
+    Address: cleanedAddress,
+    // '' can't match a select option; 'No result' mirrors clean-record's
+    // no-address sentinel for the API-failure passthrough path
+    'Address Accuracy': { name: cleanedAddressAccuracy || 'No result' },
+    ...lastRequestedFields,
+  }
+  if (Number.isFinite(binNumber)) {
+    meshFields['Building Identification Number'] = binNumber
+  }
+  output.set('meshRequestId', await meshRequestTable.createRecordAsync(meshFields))
 } else {
   output.set('meshRequestId', null)
 }


### PR DESCRIPTION
Applies the fixes for the [review findings on #52](https://github.com/bushwickayudamutua/bam-automation/pull/52#pullrequestreview-4813965644). Targets `jm/automations` so it folds into that PR.

## Blockers fixed

- **`maxMeshStatus` null-Status crash** — `create-requests.js` now sets `Status: { name: 'Open' }` on new mesh records, and `maxMeshStatus` skips null statuses. Unrecognized status names no longer silently lose: they're collected and emitted via a new `unknownMeshStatuses` output, and an unrankable group leaves the survivor's Status untouched instead of writing `undefined`.
- **`Address Accuracy: { name: '' }` rejection on the API-failure path** — defaults to `'No result'` (mirrors clean-record's no-address sentinel).

## Majors fixed

- **`clean()` crash paths** — the whole call is wrapped in try/catch and `response.ok` is checked before parsing, so HTML 502s and network errors fall back to raw form fields instead of failing the script with zero outputs.
- **Date grouping** — new `dateKey()` normalizes `Status Last Updated At` (Date object or ISO string) to a NY-local `YYYY-MM-DD` key for both grouping and the count-record lookup, so counts accumulate per day instead of creating a record per timestamp. Created records are cached so the same day isn't re-created across tables.
- **Input guards** — `reqIds?.length` in both consolidate and count scripts; an unconfigured automation input no longer crashes mid-run after earlier tables were processed.
- **Mesh over-counting** — installs count once per household phone per close date (skipped gracefully if the `Phone Number (from Household)` field doesn't exist on the table).
- **`zipcode` → `zip_code`** — the cleaning API declares `zip_code`; FastAPI was silently dropping the old param, so geocoding never received the zip.

## Minors fixed

- Empty-Type records are preserved and reported (`(empty Type)` + record ids in a new `uncountedRequestIds` output) instead of crashing the run; `invalidCountCols`/`uncountedRequestIds` are emitted in a `finally` so a later table's failure can't swallow the report.
- Merge results that are null/empty no longer clear populated survivor fields (a form-created duplicate can't null out staff-entered `Street Address`/`City, State`/`Zip Code`).
- `Roof Accessible?` and `Has LOS?` are merged (`some()` across the group) so confirmations on deleted duplicates survive.
- `internetAccess || []` guard; BIN omitted instead of written as `undefined`; unknown Address Accuracy names rank 0 (like `No result`) instead of below `Invalid Address Provided`; `Last Requested` normalized to the NY-local day of `formSubmittedAt`; whitespace-free fallback address; unused `countTable` removed.

## Deliberately not changed (flagged in review, needs a product/base decision)

- `MESH_STATUS_RANK` names vs the migration script's names — can't be resolved from the repo; the new `unknownMeshStatuses` output makes any drift visible at runtime.
- Rank ordering (`Cannot Install` > `Install Scheduled`, `INSTALL PENDING ELDERT REPAIR` > `YAY! MESH INSTALLED!`).
- Dropped `Roof Accessible?` form answer at intake, null-BIN mesh requests merging together, and the blank-phone → `Invalid Phone Number?` semantics.
- Legacy-record migration and the Airtable automation UI reconfiguration checklist from the review.

## Verification

All four scripts were run against a stubbed Airtable scripting environment exercising the review's failure scenarios (30 checks): null-Status mesh merge, unknown-status reporting, survivor-field preservation, API-failure passthrough creating a mesh record, network-error/HTML-502 fallback in clean-record, Date-object day grouping, once-per-phone mesh counting, empty-Type preservation, and unset-input tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
